### PR TITLE
spec: add IgnoredArticles attribute to Index responses

### DIFF
--- a/server/ctrlsubsonic/spec/spec.go
+++ b/server/ctrlsubsonic/spec/spec.go
@@ -134,7 +134,8 @@ type TrackChild struct {
 }
 
 type Artists struct {
-	List []*Index `xml:"index" json:"index"`
+	IgnoredArticles string   `xml:"ignoredArticles,attr" json:"ignoredArticles"`
+	List            []*Index `xml:"index"                json:"index"`
 }
 
 type Artist struct {
@@ -146,8 +147,9 @@ type Artist struct {
 }
 
 type Indexes struct {
-	LastModified int      `xml:"lastModified,attr,omitempty" json:"lastModified"`
-	Index        []*Index `xml:"index"                       json:"index"`
+	LastModified    int      `xml:"lastModified,attr,omitempty" json:"lastModified"`
+	IgnoredArticles string   `xml:"ignoredArticles,attr"        json:"ignoredArticles"`
+	Index           []*Index `xml:"index"                       json:"index"`
 }
 
 type Index struct {


### PR DESCRIPTION
This attribute is required as per spec and keeping it empty,
complies the spec as long as articles are not ignored while indexing.
In the future, this could maybe be a user setting that could be
supported.

With this change, the aurial client works now.

* https://shrimpza.github.io/aurial/
* https://github.com/shrimpza/aurial