### PR TITLE
Fix bug in createPlaylist and make createPlaylist and updatePlaylist adhere to v1.14.0 spec

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -153,7 +153,7 @@ func setupSubsonic(r *mux.Router, ctrl *ctrlsubsonic.Controller) {
 	r.Handle("/getUser{_:(?:\\.view)?}", ctrl.H(ctrl.ServeGetUser))
 	r.Handle("/getPlaylists{_:(?:\\.view)?}", ctrl.H(ctrl.ServeGetPlaylists))
 	r.Handle("/getPlaylist{_:(?:\\.view)?}", ctrl.H(ctrl.ServeGetPlaylist))
-	r.Handle("/createPlaylist{_:(?:\\.view)?}", ctrl.H(ctrl.ServeUpdatePlaylist))
+	r.Handle("/createPlaylist{_:(?:\\.view)?}", ctrl.H(ctrl.ServeCreatePlaylist))
 	r.Handle("/updatePlaylist{_:(?:\\.view)?}", ctrl.H(ctrl.ServeUpdatePlaylist))
 	r.Handle("/deletePlaylist{_:(?:\\.view)?}", ctrl.H(ctrl.ServeDeletePlaylist))
 	r.Handle("/savePlayQueue{_:(?:\\.view)?}", ctrl.H(ctrl.ServeSavePlayQueue))


### PR DESCRIPTION
Bugs this fixes:

* When you call `createPlaylist`, it is supposed to replace all of the IDs in the playlist with the IDs sent in the request. Gonic doesn't do that, instead, it appends the IDs. This is problematic for re-ordering songs in playlists in Sublime Music, since Sublime Music just sends an updated list of all of the song IDs in the playlist. The result is that all of the existing songs are duplicated in the playlist.

This PR also makes `createPlaylist` and `updatePlaylist` adhere to v1.14.0 spec:

* As of Subsonic API version 1.14.0, the updated playlist should be returned by the `createPlaylist` endpoint.