### PR TITLE
Add ListenBrainz API scrobbling support

### DIFF
--- a/server/assets/pages/home.tmpl
+++ b/server/assets/pages/home.tmpl
@@ -43,7 +43,7 @@
             <p class="text-light">api key not set</p>
             {{ if not .User.IsAdmin }}
                 <p class="text-light">please ask your admin to set it</p>
-            {{ end }}
+	          {{ end }}
         {{ end }}
         {{ if .User.IsAdmin }}
             <p><a href="{{ path "/admin/update_lastfm_api_key" }}">update api key&#8230;</a></p>
@@ -69,8 +69,8 @@
             {{ else }}
                 <span class="angry">unlinked</span>
 
-                <table id="listenbrainz-pref">
                 <form id="listenbrainz-pref-set" action="{{ path "/admin/link_listenbrainz_do" }}" method="post"></form>
+                <table id="listenbrainz-pref">
                 <tr>
                     <td><label for="listenbrainz-token">Token:</label></td>
                     <td><input form="listenbrainz-pref-set" id="listenbrainz-token" type="text" name="token" value="{{ default "" .User.ListenBrainzToken }}"></td>

--- a/server/assets/pages/home.tmpl
+++ b/server/assets/pages/home.tmpl
@@ -43,10 +43,57 @@
             <p class="text-light">api key not set</p>
             {{ if not .User.IsAdmin }}
                 <p class="text-light">please ask your admin to set it</p>
-	    {{ end }}
+            {{ end }}
         {{ end }}
         {{ if .User.IsAdmin }}
             <p><a href="{{ path "/admin/update_lastfm_api_key" }}">update api key&#8230;</a></p>
+        {{ end }}
+    </div>
+</div>
+<div class="padded box">
+    <div class="box-title">
+        <i class="mdi mdi-brain"></i> ListenBrainz
+    </div>
+    <div class="box-description text-light">
+        <p>gonic can scrobble to <a href="https://listenbrainz.org/" target="_blank">ListenBrainz</a> and compatible sites.</p>
+    </div>
+    <div class="text-right">
+        {{ if .ListenBrainzEnabled }}
+            <span class="text-light">current status</span>
+            {{ if .User.ListenBrainzToken }}
+                linked to <code>{{ .User.ListenBrainzURL  }}</code>
+                <span class="text-light">&#124;</span>
+                <form action="{{ path "/admin/unlink_listenbrainz_do" }}" method="post">
+                    <input type="submit" value="unlink">
+                </form>
+            {{ else }}
+                <span class="angry">unlinked</span>
+
+                <table id="listenbrainz-pref">
+                <form id="listenbrainz-pref-set" action="{{ path "/admin/link_listenbrainz_do" }}" method="post"></form>
+                <tr>
+                    <td><label for="listenbrainz-token">Token:</label></td>
+                    <td><input form="listenbrainz-pref-set" id="listenbrainz-token" type="text" name="token" value="{{ default "" .User.ListenBrainzToken }}"></td>
+                </tr>
+                {{ if .ListenBrainzCustomURLEnabled }}
+                <tr>
+                  <td><label for="listenbrainz-url">Custom URL:</label></td>
+                  <td><input form="listenbrainz-pref-set" id="listenbrainz-url" type="text" name="custom_url" value="{{ default "https://api.listenbrainz.org" .User.ListenBrainzURL }}"></td>
+                </tr>
+                {{ end }}
+                <tr>
+                <td colspan="2"><input form="listenbrainz-pref-set" type="submit" value="save"></td>
+                </tr>
+                </table>
+            {{ end }}
+        {{ else }}
+            <p class="text-light">not enabled</p>
+            {{ if not .User.IsAdmin }}
+                <p class="text-light">please ask your admin to enable it</p>
+	          {{ end }}
+        {{ end }}
+        {{ if .User.IsAdmin }}
+            <p><a href="{{ path "/admin/update_listenbrainz_settings" }}">update global settings&#8230;</a></p>
         {{ end }}
     </div>
 </div>

--- a/server/assets/pages/home.tmpl
+++ b/server/assets/pages/home.tmpl
@@ -43,7 +43,7 @@
             <p class="text-light">api key not set</p>
             {{ if not .User.IsAdmin }}
                 <p class="text-light">please ask your admin to set it</p>
-	          {{ end }}
+            {{ end }}
         {{ end }}
         {{ if .User.IsAdmin }}
             <p><a href="{{ path "/admin/update_lastfm_api_key" }}">update api key&#8230;</a></p>
@@ -90,7 +90,7 @@
             <p class="text-light">not enabled</p>
             {{ if not .User.IsAdmin }}
                 <p class="text-light">please ask your admin to enable it</p>
-	          {{ end }}
+            {{ end }}
         {{ end }}
         {{ if .User.IsAdmin }}
             <p><a href="{{ path "/admin/update_listenbrainz_settings" }}">update global settings&#8230;</a></p>

--- a/server/assets/pages/update_listenbrainz_settings.tmpl
+++ b/server/assets/pages/update_listenbrainz_settings.tmpl
@@ -1,0 +1,17 @@
+{{ define "user" }}
+<div class="padded box">
+    <div class="box-title">
+        <i class="mdi mdi-key-change"></i> ListenBrainz settings
+    </div>
+    <div class="box-description text-light">
+        <p>you can enable ListenBrainz support here. if custom URLs are allowed the user may set an API endpoint different from the default <code>https://api.listenbrainz.org</code>.</p>
+    </div>
+    <form class="block" action="{{ path "/admin/update_listenbrainz_settings_do" }}" method="post">
+        <label for="enabled">Allow users to use ListenBrainz</label>
+        <input type="checkbox" id="enabled" name="enabled" {{ ternary "checked" "" .ListenBrainzEnabled }}>
+        <label for="custom_url_enabled">Allow users to set a custom API endpoint</label>
+        <input type="checkbox" id="custom_url_enabled" name="custom_url_enabled" {{ ternary "checked" "" .ListenBrainzCustomURLEnabled }}>
+        <input type="submit" value="update">
+    </form>
+</div>
+{{ end }}

--- a/server/assets/pages/update_listenbrainz_settings.tmpl
+++ b/server/assets/pages/update_listenbrainz_settings.tmpl
@@ -7,10 +7,14 @@
         <p>you can enable ListenBrainz support here. if custom URLs are allowed the user may set an API endpoint different from the default <code>https://api.listenbrainz.org</code>.</p>
     </div>
     <form class="block" action="{{ path "/admin/update_listenbrainz_settings_do" }}" method="post">
-        <label for="enabled">Allow users to use ListenBrainz</label>
-        <input type="checkbox" id="enabled" name="enabled" {{ ternary "checked" "" .ListenBrainzEnabled }}>
-        <label for="custom_url_enabled">Allow users to set a custom API endpoint</label>
-        <input type="checkbox" id="custom_url_enabled" name="custom_url_enabled" {{ ternary "checked" "" .ListenBrainzCustomURLEnabled }}>
+        <div class="row">
+            <label for="enabled">Allow users to use ListenBrainz</label>
+            <input type="checkbox" id="enabled" name="enabled" {{ ternary "checked" "" .ListenBrainzEnabled }}>
+        </div>
+        <div class="row">
+            <label for="custom_url_enabled">Allow users to set a custom API endpoint</label>
+            <input type="checkbox" id="custom_url_enabled" name="custom_url_enabled" {{ ternary "checked" "" .ListenBrainzCustomURLEnabled }}>
+        </div>
         <input type="submit" value="update">
     </form>
 </div>

--- a/server/assets/static/main.css
+++ b/server/assets/static/main.css
@@ -173,3 +173,12 @@ a:hover {
 .angry {
   background-color: #f4433669;
 }
+
+#listenbrainz-pref {
+  width: 100%;
+}
+
+#listenbrainz-token,
+#listenbrainz-url {
+  width: 90%;
+}

--- a/server/assets/static/main.css
+++ b/server/assets/static/main.css
@@ -27,6 +27,7 @@ html {
 
 body {
   max-width: var(--width-body);
+  line-height: initial;
   margin: 0 auto;
   overflow-y: scroll;
 }
@@ -37,23 +38,28 @@ button,
 textarea {
   border-radius: 0;
   box-sizing: border-box;
-  margin: 0;
+  margin: calc(var(--size)*0.33) 0 0 0;
   padding: 0;
-  border: none;
-  outline: 1px solid #ccc;
-  height: var(--size);
+  border: 1px solid #ccc;
   vertical-align: middle;
 }
 
 input[type] {
   width: calc(var(--size) * 9);
   background-color: white;
-  cursor: pointer;
 }
 
 input[type="text"],
 input[type="password"] {
   width: 100%;
+}
+
+input[type="checkbox"] {
+  outline: none;
+}
+
+input[type="submit"]:hover {
+  background: #eee;
 }
 
 form {
@@ -68,6 +74,14 @@ form.block {
   flex-direction: column;
   align-items: flex-end;
   text-align: right;
+}
+
+form.block .row {
+  margin-bottom: calc(var(--size)*0.5);
+}
+
+form.block .row input[type="checkbox"] {
+  width: unset;
 }
 
 form > * {
@@ -176,9 +190,6 @@ a:hover {
 
 #listenbrainz-pref {
   width: 100%;
+  margin: calc(var(--size)*0.5) 0;
 }
 
-#listenbrainz-token,
-#listenbrainz-url {
-  width: 90%;
-}

--- a/server/ctrladmin/ctrl.go
+++ b/server/ctrladmin/ctrl.go
@@ -120,9 +120,11 @@ type templateData struct {
 	TranscodePreferences []*db.TranscodePreference
 	TranscodeProfiles    []string
 	//
-	CurrentLastFMAPIKey    string
-	CurrentLastFMAPISecret string
-	SelectedUser           *db.User
+	CurrentLastFMAPIKey          string
+	CurrentLastFMAPISecret       string
+	ListenBrainzEnabled          bool
+	ListenBrainzCustomURLEnabled bool
+	SelectedUser                 *db.User
 }
 
 type Response struct {

--- a/server/ctrladmin/handlers.go
+++ b/server/ctrladmin/handlers.go
@@ -171,9 +171,9 @@ func (c *Controller) ServeLinkListenBrainzDo(r *http.Request) *Response {
 			code: 400,
 		}
 	}
-	custom_url_enabled := c.DB.GetBoolSetting("listenbrainz_custom_url_enabled", false)
-	custom_url := r.FormValue("custom_url")
-	if custom_url_enabled && custom_url == "" {
+	customURLEnabled := c.DB.GetBoolSetting("listenbrainz_custom_url_enabled", false)
+	customURL := r.FormValue("custom_url")
+	if customURLEnabled && customURL == "" {
 		return &Response{
 			err:  "please provide a custom_url, even if it is the default one",
 			code: 400,
@@ -181,8 +181,8 @@ func (c *Controller) ServeLinkListenBrainzDo(r *http.Request) *Response {
 	}
 	user := r.Context().Value(CtxUser).(*db.User)
 	user.ListenBrainzToken = token
-	if custom_url_enabled {
-		user.ListenBrainzURL = custom_url
+	if customURLEnabled {
+		user.ListenBrainzURL = customURL
 	} else {
 		user.ListenBrainzURL = ""
 	}
@@ -382,9 +382,9 @@ func (c *Controller) ServeUpdateListenBrainzSettings(r *http.Request) *Response 
 
 func (c *Controller) ServeUpdateListenBrainzSettingsDo(r *http.Request) *Response {
 	enabled := r.FormValue("enabled") == "on"
-	customUrlEnabled := r.FormValue("custom_url_enabled") == "on"
+	customURLEnabled := r.FormValue("custom_url_enabled") == "on"
 	c.DB.SetBoolSetting("listenbrainz_enabled", enabled)
-	c.DB.SetBoolSetting("listenbrainz_custom_url_enabled", customUrlEnabled)
+	c.DB.SetBoolSetting("listenbrainz_custom_url_enabled", customURLEnabled)
 	return &Response{redirect: "/admin/home"}
 }
 

--- a/server/ctrlsubsonic/handlers_common.go
+++ b/server/ctrlsubsonic/handlers_common.go
@@ -86,9 +86,9 @@ func (c *Controller) ServeScrobble(r *http.Request) *spec.Response {
 	}
 	// fetch user to get lastfm session
 	user := r.Context().Value(CtxUser).(*db.User)
-	lastfm_usable := user.LastFMSession != ""
-	listenbrainz_usable := c.DB.GetBoolSetting("listenbrainz_enabled", false) && user.ListenBrainzToken != ""
-	if !lastfm_usable && !listenbrainz_usable {
+	lastfmUsable := user.LastFMSession != ""
+	listenbrainzUsable := c.DB.GetBoolSetting("listenbrainz_enabled", false) && user.ListenBrainzToken != ""
+	if !lastfmUsable && !listenbrainzUsable {
 		return spec.NewError(0, "you don't have a last.fm/listenbrainz session")
 	}
 	// fetch track for getting info to send to last.fm function
@@ -98,14 +98,14 @@ func (c *Controller) ServeScrobble(r *http.Request) *spec.Response {
 		Preload("Artist").
 		First(track, id.Value)
 	// scrobble with above info to lastfm
-	if lastfm_usable {
+	if lastfmUsable {
 		fail := c.scrobbleLastFM(user, track, params)
 		if fail != nil {
 			return fail
 		}
 	}
 	// scrobble to listenbrainz
-	if listenbrainz_usable {
+	if listenbrainzUsable {
 		fail := c.scrobbleListenBrainz(user, track, params)
 		if fail != nil {
 			return fail

--- a/server/ctrlsubsonic/handlers_common.go
+++ b/server/ctrlsubsonic/handlers_common.go
@@ -60,9 +60,9 @@ func (c *Controller) scrobbleLastFM(user *db.User, track *db.Track, params param
 
 func (c *Controller) scrobbleListenBrainz(user *db.User, track *db.Track, params params.Params) *spec.Response {
 	opts := listenbrainz.ScrobbleOptions{
-		Track: track,
-		UnixTimestampS:  params.GetOrInt("time", int(time.Now().Unix())),
-		Submission: params.GetOrBool("submission", true),
+		Track:          track,
+		UnixTimestampS: int64(params.GetOrInt("time", int(time.Now().Unix()))),
+		Submission:     params.GetOrBool("submission", true),
 	}
 	err := listenbrainz.Scrobble(
 		c.DB.GetBoolSetting("listenbrainz_enabled", false),
@@ -106,10 +106,10 @@ func (c *Controller) ServeScrobble(r *http.Request) *spec.Response {
 	}
 	// scrobble to listenbrainz
 	if listenbrainz_usable {
-			fail := c.scrobbleListenBrainz(user, track, params)
-			if fail != nil {
-				return fail
-			}
+		fail := c.scrobbleListenBrainz(user, track, params)
+		if fail != nil {
+			return fail
+		}
 	}
 	return spec.NewResponse()
 }

--- a/server/db/db.go
+++ b/server/db/db.go
@@ -5,6 +5,7 @@ import (
 	"log"
 	"net/url"
 	"os"
+	"strconv"
 
 	"github.com/gorilla/securecookie"
 	"github.com/jinzhu/gorm"
@@ -76,6 +77,7 @@ func New(path string) (*DB, error) {
 		migrateAddGenre(),
 		migrateUpdateTranscodePrefIDX(),
 		migrateAddAlbumIDX(),
+		migrateAddListenBrainz(),
 	))
 	if err = migr.Migrate(); err != nil {
 		return nil, fmt.Errorf("migrating to latest version: %w", err)
@@ -100,6 +102,18 @@ func (db *DB) SetSetting(key, value string) {
 		Where(Setting{Key: key}).
 		Assign(Setting{Value: value}).
 		FirstOrCreate(&Setting{})
+}
+
+func (db *DB) GetBoolSetting(key string, fallback bool) bool {
+	value, err := strconv.ParseBool(db.GetSetting(key))
+	if err != nil {
+		return fallback
+	}
+	return value
+}
+
+func (db *DB) SetBoolSetting(key string, value bool) {
+	db.SetSetting(key, strconv.FormatBool(value))
 }
 
 func (db *DB) GetOrCreateKey(key string) string {

--- a/server/db/migrations.go
+++ b/server/db/migrations.go
@@ -153,3 +153,16 @@ func migrateAddAlbumIDX() gormigrate.Migration {
 		},
 	}
 }
+
+func migrateAddListenBrainz() gormigrate.Migration {
+	return gormigrate.Migration{
+		ID: "202009131937",
+		Migrate: func(tx *gorm.DB) error {
+			return tx.AutoMigrate(
+				User{},
+				Setting{},
+			).
+				Error
+		},
+	}
+}

--- a/server/db/model.go
+++ b/server/db/model.go
@@ -129,12 +129,14 @@ func (t *Track) RelPath() string {
 }
 
 type User struct {
-	ID            int `gorm:"primary_key"`
-	CreatedAt     time.Time
-	Name          string `gorm:"not null; unique_index" sql:"default: null"`
-	Password      string `gorm:"not null" sql:"default: null"`
-	LastFMSession string `sql:"default: null"`
-	IsAdmin       bool   `sql:"default: null"`
+	ID                int `gorm:"primary_key"`
+	CreatedAt         time.Time
+	Name              string `gorm:"not null; unique_index" sql:"default: null"`
+	Password          string `gorm:"not null" sql:"default: null"`
+	LastFMSession     string `sql:"default: null"`
+	ListenBrainzURL   string `sql:"default: null"`
+	ListenBrainzToken string `sql:"default: null"`
+	IsAdmin           bool   `sql:"default: null"`
 }
 
 type Setting struct {

--- a/server/listenbrainz/listenbrainz.go
+++ b/server/listenbrainz/listenbrainz.go
@@ -1,0 +1,112 @@
+package listenbrainz
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+
+	"go.senan.xyz/gonic/server/db"
+)
+
+const (
+	defaultURL = "https://api.listenbrainz.org"
+)
+
+var (
+	ErrListenBrainz = errors.New("listenbrainz error")
+)
+
+type ScrobbleOptions struct {
+	Track          *db.Track
+	UnixTimestampS int
+	Submission     bool
+}
+
+type trackMetadata struct {
+	ArtistName     string                 `json:"artist_name"`
+	TrackName      string                 `json:"track_name"`
+	ReleaseName    string                 `json:"release_name, omitempty"`
+	AdditionalInfo map[string]interface{} `json:"additional_info"`
+}
+
+type scrobblePayload struct {
+	ListenedAt    int           `json:"listened_at, omitempty"` // missing from playing_now
+	TrackMetadata trackMetadata `json:"track_metadata"`
+}
+
+type scrobbleRequest struct {
+	ListenType string            `json:"listen_type"` // single, playing_now, import
+	Payload    []scrobblePayload `json:"payload"`
+}
+
+func makeRequest(baseURL, token, method string, scrobble scrobbleRequest) error {
+	apiURL := baseURL + "/1/submit-listens"
+	jsonValue, err := json.Marshal(scrobble)
+	if err != nil {
+		return fmt.Errorf("json: %w", err)
+	}
+	postBody := bytes.NewReader(jsonValue)
+	req, _ := http.NewRequest(method, apiURL, postBody)
+	req.Header.Set("Authorization", "token "+token)
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("get: %w", err)
+	}
+	defer resp.Body.Close()
+
+	return nil
+}
+
+func Scrobble(listenbrainzEnabled, customURLEnabled bool, token, customURL string, opts ScrobbleOptions) error {
+	if !listenbrainzEnabled {
+		return nil
+	}
+	baseURL := defaultURL
+	if customURLEnabled && customURL != "" {
+		baseURL = customURL
+	}
+	// required fields
+	payload := scrobblePayload{
+		TrackMetadata: trackMetadata{
+			ArtistName:     opts.Track.TagTrackArtist,
+			TrackName:      opts.Track.TagTitle,
+			AdditionalInfo: make(map[string]interface{}),
+		},
+	}
+	// optional
+	if opts.Track.Album.TagTitle != "" {
+		payload.TrackMetadata.ReleaseName = opts.Track.Album.TagTitle
+	}
+	// optional "official" fields,
+	// see https://listenbrainz.readthedocs.io/en/production/dev/json/#submission-json
+	if opts.Track.TagTrackNumber > 0 {
+		payload.TrackMetadata.AdditionalInfo["tracknumber"] = opts.Track.TagTrackNumber
+	}
+	if opts.Track.TagBrainzID != "" {
+		payload.TrackMetadata.AdditionalInfo["track_mbid"] = opts.Track.TagBrainzID
+	}
+	// our custom additional fields
+	if opts.Track.Artist.Name != "" {
+		payload.TrackMetadata.AdditionalInfo["release_artist"] = opts.Track.Artist.Name
+	}
+	if opts.Track.Length > 0 {
+		payload.TrackMetadata.AdditionalInfo["track_length"] = opts.Track.Length
+	}
+
+	scrobble := scrobbleRequest{
+		Payload: make([]scrobblePayload, 1),
+	}
+	if opts.Submission {
+		scrobble.ListenType = "single"
+		payload.ListenedAt = opts.UnixTimestampS
+	} else {
+		// no timestamp for playing_now
+		scrobble.ListenType = "playing_now"
+	}
+	scrobble.Payload[0] = payload
+
+	return makeRequest(baseURL, token, "POST", scrobble)
+}

--- a/server/listenbrainz/listenbrainz.go
+++ b/server/listenbrainz/listenbrainz.go
@@ -1,112 +1,60 @@
 package listenbrainz
 
 import (
-	"bytes"
-	"encoding/json"
 	"errors"
 	"fmt"
-	"net/http"
 
-	"go.senan.xyz/gonic/server/db"
-)
-
-const (
-	defaultURL = "https://api.listenbrainz.org"
+	"github.com/spezifisch/go-listenbrainz"
 )
 
 var (
+	// ErrListenBrainz means you gave wrong parameters
 	ErrListenBrainz = errors.New("listenbrainz error")
 )
 
-type ScrobbleOptions struct {
-	Track          *db.Track
-	UnixTimestampS int
-	Submission     bool
-}
-
-type trackMetadata struct {
-	ArtistName     string                 `json:"artist_name"`
-	TrackName      string                 `json:"track_name"`
-	ReleaseName    string                 `json:"release_name, omitempty"`
-	AdditionalInfo map[string]interface{} `json:"additional_info"`
-}
-
-type scrobblePayload struct {
-	ListenedAt    int           `json:"listened_at, omitempty"` // missing from playing_now
-	TrackMetadata trackMetadata `json:"track_metadata"`
-}
-
-type scrobbleRequest struct {
-	ListenType string            `json:"listen_type"` // single, playing_now, import
-	Payload    []scrobblePayload `json:"payload"`
-}
-
-func makeRequest(baseURL, token, method string, scrobble scrobbleRequest) error {
-	apiURL := baseURL + "/1/submit-listens"
-	jsonValue, err := json.Marshal(scrobble)
-	if err != nil {
-		return fmt.Errorf("json: %w", err)
-	}
-	postBody := bytes.NewReader(jsonValue)
-	req, _ := http.NewRequest(method, apiURL, postBody)
-	req.Header.Set("Authorization", "token "+token)
-	req.Header.Set("Content-Type", "application/json")
-	resp, err := http.DefaultClient.Do(req)
-	if err != nil {
-		return fmt.Errorf("get: %w", err)
-	}
-	defer resp.Body.Close()
-
-	return nil
-}
-
+// Scrobble submits the track given in opts to the given ListenBrainz server if enabled
 func Scrobble(listenbrainzEnabled, customURLEnabled bool, token, customURL string, opts ScrobbleOptions) error {
 	if !listenbrainzEnabled {
 		return nil
 	}
-	baseURL := defaultURL
+	api := listenbrainz.GetDefaultAPI()
 	if customURLEnabled && customURL != "" {
-		baseURL = customURL
+		api.URL = customURL
 	}
 	// required fields
-	payload := scrobblePayload{
-		TrackMetadata: trackMetadata{
-			ArtistName:     opts.Track.TagTrackArtist,
-			TrackName:      opts.Track.TagTitle,
-			AdditionalInfo: make(map[string]interface{}),
-		},
+	if opts.Track == nil {
+		return fmt.Errorf("opts.Track is nil: %w", ErrListenBrainz)
+	}
+	track := listenbrainz.Track{
+		Artist:         opts.Track.TagTrackArtist,
+		Title:          opts.Track.TagTitle,
+		AdditionalInfo: make(map[string]interface{}),
 	}
 	// optional
-	if opts.Track.Album.TagTitle != "" {
-		payload.TrackMetadata.ReleaseName = opts.Track.Album.TagTitle
+	if opts.Track.Album != nil && opts.Track.Album.TagTitle != "" {
+		track.Album = opts.Track.Album.TagTitle
 	}
 	// optional "official" fields,
 	// see https://listenbrainz.readthedocs.io/en/production/dev/json/#submission-json
 	if opts.Track.TagTrackNumber > 0 {
-		payload.TrackMetadata.AdditionalInfo["tracknumber"] = opts.Track.TagTrackNumber
+		track.AdditionalInfo["tracknumber"] = opts.Track.TagTrackNumber
 	}
 	if opts.Track.TagBrainzID != "" {
-		payload.TrackMetadata.AdditionalInfo["track_mbid"] = opts.Track.TagBrainzID
+		track.AdditionalInfo["track_mbid"] = opts.Track.TagBrainzID
 	}
 	// our custom additional fields
-	if opts.Track.Artist.Name != "" {
-		payload.TrackMetadata.AdditionalInfo["release_artist"] = opts.Track.Artist.Name
+	if opts.Track.Artist != nil && opts.Track.Artist.Name != "" {
+		track.AdditionalInfo["release_artist"] = opts.Track.Artist.Name
 	}
 	if opts.Track.Length > 0 {
-		payload.TrackMetadata.AdditionalInfo["track_length"] = opts.Track.Length
+		track.AdditionalInfo["track_length"] = opts.Track.Length
 	}
 
-	scrobble := scrobbleRequest{
-		Payload: make([]scrobblePayload, 1),
-	}
 	if opts.Submission {
-		scrobble.ListenType = "single"
-		payload.ListenedAt = opts.UnixTimestampS
-	} else {
-		// no timestamp for playing_now
-		scrobble.ListenType = "playing_now"
+		_, err := api.SubmitSingle(track, opts.UnixTimestampS)
+		return err
 	}
-	scrobble.Payload[0] = payload
 
-	return makeRequest(baseURL, token, "POST", scrobble)
+	_, err := api.SubmitPlayingNow(track)
+	return err
 }

--- a/server/listenbrainz/listenbrainz.go
+++ b/server/listenbrainz/listenbrainz.go
@@ -18,6 +18,7 @@ func Scrobble(listenbrainzEnabled, customURLEnabled bool, token, customURL strin
 		return nil
 	}
 	api := listenbrainz.GetDefaultAPI()
+	api.Token = token
 	if customURLEnabled && customURL != "" {
 		api.URL = customURL
 	}

--- a/server/listenbrainz/listenbrainz_test.go
+++ b/server/listenbrainz/listenbrainz_test.go
@@ -1,0 +1,23 @@
+package listenbrainz
+
+import (
+	"crypto/md5"
+	"fmt"
+	"net/url"
+	"testing"
+)
+
+func TestGetParamSignature(t *testing.T) {
+	params := url.Values{}
+	params.Add("ccc", "CCC")
+	params.Add("bbb", "BBB")
+	params.Add("aaa", "AAA")
+	params.Add("ddd", "DDD")
+	actual := getParamSignature(params, "secret")
+	expected := fmt.Sprintf("%x", md5.Sum([]byte(
+		"aaaAAAbbbBBBcccCCCdddDDDsecret",
+	)))
+	if actual != expected {
+		t.Errorf("expected %x, got %s", expected, actual)
+	}
+}

--- a/server/listenbrainz/listenbrainz_test.go
+++ b/server/listenbrainz/listenbrainz_test.go
@@ -15,7 +15,7 @@ func TestScrobbleDisabled(t *testing.T) {
 
 func TestScrobbleTrackNil(t *testing.T) {
 	url := "foo"
-	token := "foo"
+	token := "bar"
 	opts := ScrobbleOptions{
 		Track: nil,
 	}
@@ -27,7 +27,7 @@ func TestScrobbleTrackNil(t *testing.T) {
 
 func TestScrobble(t *testing.T) {
 	url := "http://127.0.0.1:0"
-	token := "foo"
+	token := "baz"
 	track := db.Track{}
 	opts := ScrobbleOptions{
 		Track:      &track,
@@ -47,10 +47,10 @@ func TestScrobble(t *testing.T) {
 	track.TagBrainzID = "23"
 	track.Length = 23
 	track.Album = &db.Album{
-		TagTitle: "foo",
+		TagTitle: "foobar",
 	}
 	track.Artist = &db.Artist{
-		Name: "foo",
+		Name: "barfoo",
 	}
 	err = Scrobble(true, true, url, token, opts)
 	if err == nil {

--- a/server/listenbrainz/models.go
+++ b/server/listenbrainz/models.go
@@ -1,0 +1,10 @@
+package listenbrainz
+
+type LastFM struct {
+	Error   Error
+}
+
+type Error struct {
+	Code  uint
+	Value string
+}

--- a/server/listenbrainz/models.go
+++ b/server/listenbrainz/models.go
@@ -1,10 +1,11 @@
 package listenbrainz
 
-type LastFM struct {
-	Error   Error
-}
+import "go.senan.xyz/gonic/server/db"
 
-type Error struct {
-	Code  uint
-	Value string
+// ScrobbleOptions contains the track info, timestamp when listening started,
+// and whether it's a submission or nowplaying scrobble
+type ScrobbleOptions struct {
+	Track          *db.Track
+	UnixTimestampS int64
+	Submission     bool
 }

--- a/server/server.go
+++ b/server/server.go
@@ -120,6 +120,8 @@ func setupAdmin(r *mux.Router, ctrl *ctrladmin.Controller) {
 	routUser.Handle("/change_own_password_do", ctrl.H(ctrl.ServeChangeOwnPasswordDo))
 	routUser.Handle("/link_lastfm_do", ctrl.H(ctrl.ServeLinkLastFMDo))
 	routUser.Handle("/unlink_lastfm_do", ctrl.H(ctrl.ServeUnlinkLastFMDo))
+	routUser.Handle("/link_listenbrainz_do", ctrl.H(ctrl.ServeLinkListenBrainzDo))
+	routUser.Handle("/unlink_listenbrainz_do", ctrl.H(ctrl.ServeUnlinkListenBrainzDo))
 	routUser.Handle("/upload_playlist_do", ctrl.H(ctrl.ServeUploadPlaylistDo))
 	routUser.Handle("/delete_playlist_do", ctrl.H(ctrl.ServeDeletePlaylistDo))
 	routUser.Handle("/create_transcode_pref_do", ctrl.H(ctrl.ServeCreateTranscodePrefDo))
@@ -137,6 +139,8 @@ func setupAdmin(r *mux.Router, ctrl *ctrladmin.Controller) {
 	routAdmin.Handle("/create_user_do", ctrl.H(ctrl.ServeCreateUserDo))
 	routAdmin.Handle("/update_lastfm_api_key", ctrl.H(ctrl.ServeUpdateLastFMAPIKey))
 	routAdmin.Handle("/update_lastfm_api_key_do", ctrl.H(ctrl.ServeUpdateLastFMAPIKeyDo))
+	routAdmin.Handle("/update_listenbrainz_settings", ctrl.H(ctrl.ServeUpdateListenBrainzSettings))
+	routAdmin.Handle("/update_listenbrainz_settings_do", ctrl.H(ctrl.ServeUpdateListenBrainzSettingsDo))
 	routAdmin.Handle("/start_scan_inc_do", ctrl.H(ctrl.ServeStartScanIncDo))
 	routAdmin.Handle("/start_scan_full_do", ctrl.H(ctrl.ServeStartScanFullDo))
 	// middlewares should be run for not found handler


### PR DESCRIPTION
This PR adds:
* a settings page for the admin to enable ListenBrainz support globally (disabled by default)
* optionally allow users to specify a custom API endpoint. This is useful if they're running their own ListenBrainz server. It's disabled by default (only `api.listenbrainz.org` is allowed), because users could specify any server here. But you can enable this if you trust your users.
* users can enter their ListenBrainz API token (obtained from their LB profile page) to scrobble to their account
* code for the `ServeScrobble` handler. Last.fm, ListenBrainz, or both are used if configured by the user.
* some style fixes

Todo:
* Tests could be better

Tested with:
* Servers: ListenBrainz official site, musicbanana dev version
* Clients: Ultrasonic, Strawberry dev version, DSub (from F-Droid; doesn't call scrobble.view at all?)

Related:
* a scrobbler abstraction like mentioned in #68 would be nice.