### PR TITLE
Revamp the transcoding decision tree

### DIFF
--- a/server/ctrlsubsonic/handlers_raw.go
+++ b/server/ctrlsubsonic/handlers_raw.go
@@ -168,6 +168,7 @@ func (c *Controller) ServeStream(w http.ResponseWriter, r *http.Request) *spec.R
 	}
 	encodeOptions := encode.Options{
 		TrackPath:        trackPath,
+		TrackBitrate:     track.Bitrate,
 		CachePath:        c.CachePath,
 		ProfileName:      pref.Profile,
 		PreferredBitrate: params.GetOrInt("maxBitRate", 0),

--- a/server/encode/encode.go
+++ b/server/encode/encode.go
@@ -146,14 +146,6 @@ func cacheKey(sourcePath string, profileName string, profile Profile) string {
 	)
 }
 
-// getBitrate checks if the client forces bitrate lower than set in profile
-func getBitrate(preferred, defined int) int {
-	if preferred != 0 && preferred < defined {
-		return preferred
-	}
-	return defined
-}
-
 type (
 	OnInvalidProfileFunc func() error
 	OnCacheHitFunc       func(Profile, string) error
@@ -162,6 +154,7 @@ type (
 
 type Options struct {
 	TrackPath        string
+	TrackBitrate     int
 	CachePath        string
 	ProfileName      string
 	PreferredBitrate int
@@ -175,7 +168,20 @@ func Encode(opts Options) error {
 	if !ok {
 		return opts.OnInvalidProfile()
 	}
-	profile.Bitrate = getBitrate(opts.PreferredBitrate, profile.Bitrate)
+	log.Printf("client requests %dk, transcoding profile %dk, track bitrate %dk \n", opts.PreferredBitrate, profile.Bitrate, opts.TrackBitrate)
+        if opts.PreferredBitrate != 0 && opts.PreferredBitrate >= opts.TrackBitrate {
+                log.Printf("Not transcoding, requested bitrate larger or equal to track bitrate \n")
+                return opts.OnInvalidProfile()
+        } else if opts.PreferredBitrate != 0 && opts.PreferredBitrate < opts.TrackBitrate {
+                profile.Bitrate = opts.PreferredBitrate
+                log.Printf("Transcoding according to client request of %dk \n", profile.Bitrate)
+        } else if opts.PreferredBitrate == 0 && profile.Bitrate >= opts.TrackBitrate {
+                log.Printf("Not transcoding, transcoding profile bitrate larger or equal to track bitrate \n")
+                return opts.OnInvalidProfile()
+        } else {
+                log.Printf("Transcoding according to transcoding profile of %dk \n", profile.Bitrate)
+        }
+
 	cacheKey := cacheKey(opts.TrackPath, opts.ProfileName, profile)
 	cachePath := path.Join(opts.CachePath, cacheKey)
 	if fileExists(cachePath) {

--- a/server/encode/encode.go
+++ b/server/encode/encode.go
@@ -168,21 +168,19 @@ func Encode(opts Options) error {
 	if !ok {
 		return opts.OnInvalidProfile()
 	}
-
 	switch {
 	case opts.PreferredBitrate != 0 && opts.PreferredBitrate >= opts.TrackBitrate:
-		log.Printf("Not transcoding, requested bitrate larger or equal to track bitrate \n")
+		log.Printf("not transcoding, requested bitrate larger or equal to track bitrate\n")
 		return opts.OnInvalidProfile()
 	case opts.PreferredBitrate != 0 && opts.PreferredBitrate < opts.TrackBitrate:
 		profile.Bitrate = opts.PreferredBitrate
-		log.Printf("Transcoding according to client request of %dk \n", profile.Bitrate)
+		log.Printf("transcoding according to client request of %dk \n", profile.Bitrate)
 	case opts.PreferredBitrate == 0 && profile.Bitrate >= opts.TrackBitrate:
-		log.Printf("Not transcoding, profile bitrate larger or equal to track bitrate \n")
+		log.Printf("not transcoding, profile bitrate larger or equal to track bitrate\n")
 		return opts.OnInvalidProfile()
 	case opts.PreferredBitrate == 0 && profile.Bitrate < opts.TrackBitrate:
-		log.Printf("Transcoding according to transcoding profile of %dk \n", profile.Bitrate)
+		log.Printf("transcoding according to transcoding profile of %dk\n", profile.Bitrate)
 	}
-
 	cacheKey := cacheKey(opts.TrackPath, opts.ProfileName, profile)
 	cachePath := path.Join(opts.CachePath, cacheKey)
 	if fileExists(cachePath) {

--- a/server/encode/encode.go
+++ b/server/encode/encode.go
@@ -168,19 +168,20 @@ func Encode(opts Options) error {
 	if !ok {
 		return opts.OnInvalidProfile()
 	}
-	log.Printf("client requests %dk, transcoding profile %dk, track bitrate %dk \n", opts.PreferredBitrate, profile.Bitrate, opts.TrackBitrate)
-        if opts.PreferredBitrate != 0 && opts.PreferredBitrate >= opts.TrackBitrate {
-                log.Printf("Not transcoding, requested bitrate larger or equal to track bitrate \n")
-                return opts.OnInvalidProfile()
-        } else if opts.PreferredBitrate != 0 && opts.PreferredBitrate < opts.TrackBitrate {
-                profile.Bitrate = opts.PreferredBitrate
-                log.Printf("Transcoding according to client request of %dk \n", profile.Bitrate)
-        } else if opts.PreferredBitrate == 0 && profile.Bitrate >= opts.TrackBitrate {
-                log.Printf("Not transcoding, transcoding profile bitrate larger or equal to track bitrate \n")
-                return opts.OnInvalidProfile()
-        } else {
-                log.Printf("Transcoding according to transcoding profile of %dk \n", profile.Bitrate)
-        }
+
+	switch {
+	case opts.PreferredBitrate != 0 && opts.PreferredBitrate >= opts.TrackBitrate:
+		log.Printf("Not transcoding, requested bitrate larger or equal to track bitrate \n")
+		return opts.OnInvalidProfile()
+	case opts.PreferredBitrate != 0 && opts.PreferredBitrate < opts.TrackBitrate:
+		profile.Bitrate = opts.PreferredBitrate
+		log.Printf("Transcoding according to client request of %dk \n", profile.Bitrate)
+	case opts.PreferredBitrate == 0 && profile.Bitrate >= opts.TrackBitrate:
+		log.Printf("Not transcoding, profile bitrate larger or equal to track bitrate \n")
+		return opts.OnInvalidProfile()
+	case opts.PreferredBitrate == 0 && profile.Bitrate < opts.TrackBitrate:
+		log.Printf("Transcoding according to transcoding profile of %dk \n", profile.Bitrate)
+	}
 
 	cacheKey := cacheKey(opts.TrackPath, opts.ProfileName, profile)
 	cachePath := path.Join(opts.CachePath, cacheKey)


### PR DESCRIPTION
I made changes to the transcoding decisions to accommodate client requests. This is to avoid transcoding lossy file formats like mp3s when not necessary.

The logging is pretty verbose to show what is going on, feel free to remove it.

**Example 1**. The client  requests bitrate less than 320k, requested file is FLAC
```
2020/09/20 11:00:32 client requests 320k, transcoding profile 128k, track bitrate 572k
2020/09/20 11:00:32 Transcoding according to client request of 320k
2020/09/20 11:00:32 serving transcode `03 Lucky To Be Me.flac`: cache [mp3/320k] miss!
```
The client preference (320k) takes precedence over the server profile (128k) setting. This effectively dynamically adapts the transcoding profile to what the client wants.

**Example 2**. The client  requests bitrate less than 320k, requested file is mp3 
```
2020/09/20 10:56:27 client requests 320k, transcoding profile 128k, track bitrate 240k
2020/09/20 10:56:27 Not transcoding, requested bitrate larger or equal to track bitrate
2020/09/20 10:56:27 serving raw "04 - Detlef Schrempf.mp3"
```
Even though the file's bitrate is larger than the transcoding profile, it still matches client preferences so it's served raw to avoid transcoding. 

**Example 3** The client has no preference (maxBitRate=0), requested file is FLAC
```
2020/09/20 11:05:37 client requests 0k, transcoding profile 128k, track bitrate 722k
2020/09/20 11:05:37 Transcoding according to transcoding profile of 128k
2020/09/20 11:05:37 serving transcode `08 Don´t Wait.flac`: cache [mp3/128k] miss!
````
If the client requests maxBitRate=0 (unlimited), the server transcoding profile applies.

**Example 4** The client has no preference (maxBitRate=0), requested file is a small mp3
```
2020/09/20 11:08:58 client requests 0k, transcoding profile 128k, track bitrate 128k
2020/09/20 11:08:58 Not transcoding, transcoding profile bitrate larger or equal to track bitrate
2020/09/20 11:08:58 serving raw "Jethro Tull - 07 - Too Old To Rock 'n' Roll, Too Young To Die.mp3"
```

Note that with the current behavior, all four examples would be transcoded to 128k.

This is a fairly simple change, but also my first time dealing with Go so please review for mistakes.