### PR TITLE
Allow admin to set encoding profiles for all users

### DIFF
--- a/server/ctrlsubsonic/handlers_raw.go
+++ b/server/ctrlsubsonic/handlers_raw.go
@@ -28,7 +28,7 @@ import (
 func streamGetTransPref(dbc *db.DB, userID int, client string) db.TranscodePreference {
 	pref := db.TranscodePreference{}
 	dbc.
-		Where("user_id=?", userID).
+		Where("user_id=1 OR user_id=?", userID).
 		Where("client COLLATE NOCASE IN (?)", []string{"*", client}).
 		Order("client DESC"). // ensure "*" is last if it's there
 		First(&pref)


### PR DESCRIPTION
I am not sure if this is the intended usage, but I only log in to Gonic as the admin user, and I expected encoding settings to be global. This allows all users to pick up the admin settings so you don't have to re-do these each time.