### PR TITLE
Wrap the filePath in quotes

### DIFF
--- a/server/encode/encode.go
+++ b/server/encode/encode.go
@@ -87,7 +87,7 @@ func cmdOutputWrite(out, cache io.Writer, pipeReader io.ReadCloser) {
 func ffmpegCommand(filePath string, profile Profile) *exec.Cmd {
 	args := []string{
 		"-v", "0",
-		"-i", filePath,
+		"-i", fmt.Sprintf("'%s'", filePath),
 		"-map", "0:0",
 		"-vn",
 		"-b:a", fmt.Sprintf("%dk", profile.Bitrate),


### PR DESCRIPTION
Encoding a filename with spaces (or possibly dashes?) seems to get messy, so best to just wrap it in quotes so ffmpeg doesn't do anything smart with it.