### PR TITLE
Mark cache files as partial until `ffmpeg` finishes without errors

### DIFF
--- a/server/encode/encode.go
+++ b/server/encode/encode.go
@@ -139,7 +139,7 @@ func encode(out io.Writer, trackPath, cachePath string, profile Profile) error {
 	}
 	_ = cacheFile.Close()
 	// rename cache part file to mark it as valid cache file
-	os.Rename(cachePartPath, cachePath)
+	_ = os.Rename(cachePartPath, cachePath)
 	return nil
 }
 


### PR DESCRIPTION
At the moment Gonic writes data that comes from `ffmpeg` to cache files right away, and it may result in incomplete cache files (e.g. if either `ffmpeg` or Gonic crash mid-transcode). This PR adds a fairly stupid workaround: write to a `.part` file and rename it after it's been written to successfully.