### PR TITLE
Add year to TrackChilds of an Album

### DIFF
--- a/server/ctrlsubsonic/spec/construct_by_tags.go
+++ b/server/ctrlsubsonic/spec/construct_by_tags.go
@@ -50,6 +50,7 @@ func NewTrackByTags(t *db.Track, album *db.Album) *TrackChild {
 		Duration: t.Length,
 		Bitrate:  t.Bitrate,
 		Type:     "music",
+		Year:     album.TagYear,
 	}
 	if album.Cover != "" {
 		ret.CoverID = album.SID()

--- a/server/ctrlsubsonic/spec/spec.go
+++ b/server/ctrlsubsonic/spec/spec.go
@@ -140,6 +140,7 @@ type TrackChild struct {
 	TrackNumber int        `xml:"track,attr,omitempty"       json:"track,omitempty"`
 	DiscNumber  int        `xml:"discNumber,attr,omitempty"  json:"discNumber,omitempty"`
 	Type        string     `xml:"type,attr,omitempty"        json:"type,omitempty"`
+	Year        int        `xml:"year,attr,omitempty"        json:"year,omitempty"`
 }
 
 type Artists struct {

--- a/server/ctrlsubsonic/testdata/test_get_album_with_cover
+++ b/server/ctrlsubsonic/testdata/test_get_album_with_cover
@@ -37,7 +37,8 @@
           "title": "Snake Charmer",
           "track": 1,
           "discNumber": 1,
-          "type": "music"
+          "type": "music",
+          "year": 1983
         },
         {
           "album": "Snake Charmer",
@@ -59,7 +60,8 @@
           "title": "Hold On to Your Dreams",
           "track": 2,
           "discNumber": 1,
-          "type": "music"
+          "type": "music",
+          "year": 1983
         },
         {
           "album": "Snake Charmer",
@@ -81,7 +83,8 @@
           "title": "It Was a Camel",
           "track": 3,
           "discNumber": 1,
-          "type": "music"
+          "type": "music",
+          "year": 1983
         },
         {
           "album": "Snake Charmer",
@@ -103,7 +106,8 @@
           "title": "Sleazy",
           "track": 4,
           "discNumber": 1,
-          "type": "music"
+          "type": "music",
+          "year": 1983
         },
         {
           "album": "Snake Charmer",
@@ -125,7 +129,8 @@
           "title": "Snake Charmer (reprise)",
           "track": 5,
           "discNumber": 1,
-          "type": "music"
+          "type": "music",
+          "year": 1983
         }
       ]
     }


### PR DESCRIPTION
Hello,

This commit adds the album TagYear to the year field of every TrackChilds (when using tag browsing).

This allows implementations that don't support the Year field of albums (introduced in Subsonic 1.10.1) to derive the album year anyways. For information [Ultrasonic](https://github.com/ultrasonic/ultrasonic) behaves like this. 

In my setup I only use the tag browsing, but I think it might be useful to add it to NewTCTrackByFolder:construct_by_folder:39 as well. Tell me if you want me to add it to the PR.

Thanks with your work on this project otherwise, it's very nice !