### PR TITLE
fix: add image building workload on tag creation

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -13,19 +13,19 @@ jobs:
         platform: [ubuntu-latest]
     runs-on: ${{ matrix.platform }}
     steps:
-    - name: Setup Go ${{ matrix.go-version }}
-      uses: actions/setup-go@v1
-      with:
-        go-version: ${{ matrix.go-version }}
-    - name: Checkout code into the Go module directory
-      uses: actions/checkout@v1
-    - name: Install dependencies
-      run: |
-        sudo apt update
-        sudo apt install build-essential git sqlite libtag1-dev ffmpeg libasound-dev
-    - name: Lint
-      uses: golangci/golangci-lint-action@v2
-      with:
-        version: v1.33
-    - name: Test
-      run: go test ./...
+      - name: Setup Go ${{ matrix.go-version }}
+        uses: actions/setup-go@v1
+        with:
+          go-version: ${{ matrix.go-version }}
+      - name: Checkout code into the Go module directory
+        uses: actions/checkout@v1
+      - name: Install dependencies
+        run: |
+          sudo apt update
+          sudo apt install build-essential git sqlite libtag1-dev ffmpeg libasound-dev
+      - name: Lint
+        uses: golangci/golangci-lint-action@v2
+        with:
+          version: v1.33
+      - name: Test
+        run: go test ./...

--- a/.github/workflows/image.yml
+++ b/.github/workflows/image.yml
@@ -1,8 +1,6 @@
 name: main
 on:
   push:
-    branches: 
-      - master
     tags:
       - v*
   workflow_dispatch:

--- a/.github/workflows/image.yml
+++ b/.github/workflows/image.yml
@@ -1,13 +1,11 @@
-name: main
+name: image
 on:
   push:
     tags:
       - v*
   workflow_dispatch:
-
 env:
   REGISTRY_IMAGE: sentriz/gonic
-
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -15,7 +13,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
-
       - name: Set up Docker Buildx
         id: buildx
         uses: docker/setup-buildx-action@v1
@@ -23,13 +20,11 @@ jobs:
           install: true
           version: latest
           driver-opts: image=moby/buildkit:master
-
       - name: Login to DockerHub
         uses: docker/login-action@v1
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_PASSWORD }}
-
       - name: Build and Push
         uses: docker/build-push-action@v2
         with:

--- a/.github/workflows/image.yml
+++ b/.github/workflows/image.yml
@@ -24,7 +24,7 @@ jobs:
         uses: docker/login-action@v1
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_PASSWORD }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
       - name: Build and Push
         uses: docker/build-push-action@v2
         with:

--- a/.github/workflows/image.yml
+++ b/.github/workflows/image.yml
@@ -1,0 +1,44 @@
+name: main
+on:
+  push:
+    branches: 
+      - master
+    tags:
+      - v*
+  workflow_dispatch:
+
+env:
+  REGISTRY_IMAGE: sentriz/gonic
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    if: "!contains(github.event.head_commit.message, '[ci-skip]')"
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Set up Docker Buildx
+        id: buildx
+        uses: docker/setup-buildx-action@v1
+        with:
+          install: true
+          version: latest
+          driver-opts: image=moby/buildkit:master
+
+      - name: Login to DockerHub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_PASSWORD }}
+
+      - name: Build and Push
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          file: ./Dockerfile
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: |
+            ${{ env.REGISTRY_IMAGE }}:latest
+            ${{ env.REGISTRY_IMAGE }}:${GITHUB_REF##*/}


### PR DESCRIPTION
This requires the maintainer setting the DOCKERHUB_USERNAME and DOCKERHUB_PASSWORD secrets in the workflow settings on this repo.

This also adds multiarch support for amd64 and arm64 images.