### PR TITLE
make finding podcast feed audio more robust and use user provided feed urls

### DIFF
--- a/server/ctrladmin/handlers.go
+++ b/server/ctrladmin/handlers.go
@@ -431,7 +431,7 @@ func (c *Controller) ServePodcastAddDo(r *http.Request) *Response {
 			flashW:   []string{fmt.Sprintf("could not create feed: %v", err)},
 		}
 	}
-	if _, err = c.Podcasts.AddNewPodcast(feed, user.ID); err != nil {
+	if _, err = c.Podcasts.AddNewPodcast(rssURL, feed, user.ID); err != nil {
 		return &Response{
 			redirect: "/admin/home",
 			flashW:   []string{fmt.Sprintf("could not create feed: %v", err)},

--- a/server/ctrlsubsonic/handlers_podcast.go
+++ b/server/ctrlsubsonic/handlers_podcast.go
@@ -50,7 +50,7 @@ func (c *Controller) ServeCreatePodcastChannel(r *http.Request) *spec.Response {
 	if err != nil {
 		return spec.NewError(10, "failed to parse feed: %s", err)
 	}
-	if _, err = c.Podcasts.AddNewPodcast(feed, user.ID); err != nil {
+	if _, err = c.Podcasts.AddNewPodcast(rssURL, feed, user.ID); err != nil {
 		return spec.NewError(10, "failed to add feed: %s", err)
 	}
 	return spec.NewResponse()

--- a/server/podcasts/podcasts.go
+++ b/server/podcasts/podcasts.go
@@ -70,13 +70,14 @@ func (p *Podcasts) GetPodcastEpisodes(podcastID int) ([]*db.PodcastEpisode, erro
 	return episodes, nil
 }
 
-func (p *Podcasts) AddNewPodcast(feed *gofeed.Feed, userID int) (*db.Podcast, error) {
+func (p *Podcasts) AddNewPodcast(rssURL string, feed *gofeed.Feed,
+	userID int) (*db.Podcast, error) {
 	podcast := db.Podcast{
 		Description: feed.Description,
 		ImageURL:    feed.Image.URL,
 		UserID:      userID,
 		Title:       feed.Title,
-		URL:         feed.FeedLink,
+		URL:         rssURL,
 	}
 	podPath := podcast.Fullpath(p.PodcastBasePath)
 	err := os.Mkdir(podPath, 0755)


### PR DESCRIPTION
this will check that if there is no type field in an enclosure that the url ends with an audio filename, if none of these are true, itll then check audio:content for an item and do those checks again.

this was reported to be an issue as episodes werent showing up in #117 which it should fix 

This will also fix feeds that dont contain a feed url not updating  also mentioned in #117