### PR TITLE
List /podcasts as a volume in dockerfiles

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,7 +26,7 @@ COPY --from=builder \
 COPY --from=builder \
   /src/gonic \
   /bin/
-VOLUME ["/data", "/music", "/cache"]
+VOLUME ["/cache", "/data", "/music", "/podcasts"]
 EXPOSE 80
 ENV TZ ""
 ENV GONIC_DB_PATH /data/gonic.db

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -26,7 +26,7 @@ COPY --from=builder \
 COPY --from=builder \
   /src/gonic \
   /bin/
-VOLUME ["/data", "/music", "/cache"]
+VOLUME ["/cache", "/data", "/music", "/podcasts"]
 EXPOSE 80
 ENV GONIC_DB_PATH /data/gonic.db
 ENV GONIC_LISTEN_ADDR :80


### PR DESCRIPTION
When I pulled the latest `sentriz/gonic` from Docker Hub, my container failed to start because I didn't have anything mounted to `/podcasts`.  If we list `/podcasts` as a volume in the Dockerfile, docker should automatically create the directory if it doesn't exist.

I tested this change locally.