### PR TITLE
add flag (-http-log) to disable http request logging

### DIFF
--- a/cmd/gonic/main.go
+++ b/cmd/gonic/main.go
@@ -37,6 +37,7 @@ func main() {
 	confJukeboxEnabled := set.Bool("jukebox-enabled", false, "whether the subsonic jukebox api should be enabled (optional)")
 	confProxyPrefix := set.String("proxy-prefix", "", "url path prefix to use if behind proxy. eg '/gonic' (optional)")
 	confGenreSplit := set.String("genre-split", "\n", "character or string to split genre tag data on (optional)")
+	confHTTPLog := set.Bool("http-log", true, "http request logging (optional)")
 	confShowVersion := set.Bool("version", false, "show gonic version")
 	_ = set.String("config-path", "", "path to config (optional)")
 
@@ -99,6 +100,7 @@ func main() {
 		ProxyPrefix:    *confProxyPrefix,
 		GenreSplit:     *confGenreSplit,
 		PodcastPath:    *confPodcastPath,
+		HTTPLog:        *confHTTPLog,
 	})
 
 	var g run.Group

--- a/server/server.go
+++ b/server/server.go
@@ -32,6 +32,7 @@ type Options struct {
 	CoverCachePath string
 	ProxyPrefix    string
 	GenreSplit     string
+	HTTPLog        bool
 }
 
 type Server struct {
@@ -60,7 +61,9 @@ func New(opts Options) *Server {
 	}
 	// router with common wares for admin / subsonic
 	r := mux.NewRouter()
-	r.Use(base.WithLogging)
+	if opts.HTTPLog {
+		r.Use(base.WithLogging)
+	}
 	r.Use(base.WithCORS)
 	//
 	sessKey := opts.DB.GetOrCreateKey("session_key")


### PR DESCRIPTION
This mainly useful if gonic runs behind a proxy where http requests are already logged and to reduce the noise in gonic logs.