### PR TITLE
scanner/tags: prefer original_date over date

### DIFF
--- a/server/scanner/tags/tags.go
+++ b/server/scanner/tags/tags.go
@@ -45,8 +45,12 @@ func (t *Tags) Album() string         { return t.firstTag("album") }
 func (t *Tags) AlbumArtist() string   { return t.firstTag("albumartist", "album artist") }
 func (t *Tags) AlbumBrainzID() string { return t.firstTag("musicbrainz_albumid") }
 func (t *Tags) Genre() string         { return t.firstTag("genre") }
-func (t *Tags) Year() int             { return intSep(t.firstTag("date", "year"), "-") } // eg. 2019-6-11
-func (t *Tags) TrackNumber() int      { return intSep(t.firstTag("tracknumber"), "/") }  // eg. 5/12
-func (t *Tags) DiscNumber() int       { return intSep(t.firstTag("discnumber"), "/") }   // eg. 1/2
+func (t *Tags) TrackNumber() int      { return intSep(t.firstTag("tracknumber"), "/") } // eg. 5/12
+func (t *Tags) DiscNumber() int       { return intSep(t.firstTag("discnumber"), "/") }  // eg. 1/2
 func (t *Tags) Length() int           { return t.props.Length }
 func (t *Tags) Bitrate() int          { return t.props.Bitrate }
+
+func (t *Tags) Year() int {
+	// eg. 2019-6-11
+	return intSep(t.firstTag("original_date", "original_year", "date", "year"), "-")
+}


### PR DESCRIPTION
I have some re-released albums tagged with musicbrainz which sets the `date`/`year` to the date of the re-release and adds `original_date`/`original_year` to the initial release date.

I personally prefer to see the original dates when browsing my music, not sure if there is a case against it.