### PR TITLE
Support WMA files, including those with embedded album art

### DIFF
--- a/server/encode/encode.go
+++ b/server/encode/encode.go
@@ -88,7 +88,7 @@ func ffmpegCommand(filePath string, profile Profile) (*exec.Cmd, error) {
 	args := []string{
 		"-v", "0",
 		"-i", filePath,
-		"-map", "0:0",
+		"-map", "0:a:0",
 		"-vn",
 		"-b:a", fmt.Sprintf("%dk", profile.Bitrate),
 	}

--- a/server/mime/mime.go
+++ b/server/mime/mime.go
@@ -12,6 +12,7 @@ func FromExtension(ext string) (string, bool) {
 		"m4b":  "audio/m4b",
 		"ogg":  "audio/ogg",
 		"opus": "audio/ogg",
+		"wma":  "audio/x-ms-wma",
 	}
 	v, ok := types[ext]
 	return v, ok


### PR DESCRIPTION
Hello! Thank you so much for a server that Just Works with 99% of my music collection.

Unfortunately I have a few ornery .wma files that gonic doesn't detect. I made a first pass at adding them to the mimetypes:

```patch
diff --git a/server/mime/mime.go b/server/mime/mime.go
index 63c8f93..91b6277 100644
--- a/server/mime/mime.go
+++ b/server/mime/mime.go
@@ -12,6 +12,7 @@ func FromExtension(ext string) (string, bool) {
         "m4b":  "audio/m4b",
         "ogg":  "audio/ogg",
         "opus": "audio/ogg",
+        "wma":  "audio/x-ms-wma",
     }
     v, ok := types[ext]
     return v, ok
```

and that gets them successfully scanned, at least.  However, most clients don't know how to decode wma files so I'd like to transcode them. And that's where I hit problems.

Seems that my wma files have embedded album art encoded as a video stream alongside the audio:

```
Input #0, asf, from '01. Emergency Pulloff.wma':
  Metadata:
    title           : Emergency Pulloff
    artist          : Various Artists
    AverageLevel    : 7291
    FMPS/Playcount  : 0
    FMPS/Rating     : -1
    FMPS/Rating_Amarok_Score: 0
    DeviceConformanceTemplate: L1
    PeakValue       : 32033
    album_artist    : Various Artists
    album           : Stelling Banjo Anthology
    WM/EncodingTime : 1095187712
    genre           : Bluegrass
    WM/MediaPrimaryClassID: {D1607DBC-E323-4BE2-86A1-48A42A28441E}
    track           : 1
    WM/Year         : 2005
    WMFSDKNeeded    : 0.0.0.0000
    WMFSDKVersion   : 11.0.5721.5145
    IsVBR           : 0
  Duration: 00:03:11.47, start: 0.000000, bitrate: 129 kb/s
    Stream #0:0: Video: mjpeg, yuvj420p(pc, bt470bg/unknown/unknown), 200x200 [SAR 96:96 DAR 1:1], 90k tbr, 90k tbn, 90k tbc
    Metadata:
      comment         : Cover (front)
    Stream #0:1: Audio: wmav2 (a[1][0][0] / 0x0161), 44100 Hz, stereo, fltp, 128 kb/s
Output #0, opus, to '/tmp/output.opus':
Output file #0 does not contain any stream
```

The `-map 0:0` passed to ffmpeg is selecting the video stream to transcode, then `-vn` says not to transcode video, so the whole process returns an error code:

```
2021/05/28 18:59:09 transcoding according to transcoding profile of 96k
2021/05/28 18:59:09 serving transcode `02. Cotton Patch Rag.wma`: cache [opus/96k] miss!
2021/05/28 18:59:09 serving transcode `02. Cotton Patch Rag.wma`: error: starting transcode: running ffmpeg: exit status 1
```

I believe the correct solution here is to use an _audio_ stream specifier, as in `-map 0:a:0`.  Doing this selects the audio and successfully performs the transcode, and the track plays in Jamstack.

[Here's a sample track](https://nextcloud.thirtythreeforty.net/nextcloud/index.php/s/CBpTEa2T8gfAtwW) you can reproduce all this with if you like. Sorry about the banjo music :)