### PR TITLE
Strip EBU R128 gain tags when using forced-RG transcoding

### DIFF
--- a/server/encode/encode.go
+++ b/server/encode/encode.go
@@ -102,6 +102,8 @@ func ffmpegCommand(filePath string, profile Profile) (*exec.Cmd, error) {
 			"-metadata", "replaygain_album_peak=",
 			"-metadata", "replaygain_track_gain=",
 			"-metadata", "replaygain_track_peak=",
+			"-metadata", "r128_album_gain=",
+			"-metadata", "r128_track_gain=",
 		)
 	}
 	args = append(args, "-f", profile.Format, "-")


### PR DESCRIPTION
Hello @sentriz, long time no see! :)

I was messing around with my encode profiles and found that in some cases (e.g. my music library) source files can have EBU R128 gain tags alongside ordinary ReplayGain tags. If we don't instruct `ffmpeg` to strip out these tags during RG-enabled transcoding, it can confuse some client apps into thinking that the track has ReplayGain tags and should be processed accordingly. 

The main problem is that these R128 tags have a different scale than normal RG ones, and even when left with a value of `0` (zero) it can cause some clients to forcibly apply a whopping +5.0 dB gain to the track, causing clipping and occasional ear bleeding. :)

This PR fixes it by stripping these tags out. I double-checked the result (with `mediainfo` and Foobar2000) and now there are no rogue gain tags left anymore.