### PR TITLE
Add MIME-type and content length hints to cache handlers

### DIFF
--- a/server/ctrlsubsonic/handlers_raw.go
+++ b/server/ctrlsubsonic/handlers_raw.go
@@ -235,13 +235,12 @@ func (c *Controller) ServeStream(w http.ResponseWriter, r *http.Request) *spec.R
 		cacheMime, _ := mime.FromExtension(profile.Format)
 		w.Header().Set("Content-Type", cacheMime)
 
-		cacheFile, cfErr := os.Stat(path)
-		if cfErr != nil {
-			log.Printf("failed to stat cache file `%s`: %v", path, cfErr)
-		} else {
-			contentLength := fmt.Sprintf("%d", cacheFile.Size())
-			w.Header().Set("Content-Length", contentLength)
+		cacheFile, err := os.Stat(path)
+		if err != nil {
+			return fmt.Errorf("failed to stat cache file `%s`: %v", path, err)
 		}
+		contentLength := fmt.Sprintf("%d", cacheFile.Size())
+		w.Header().Set("Content-Length", contentLength)
 		http.ServeFile(w, r, path)
 		return nil
 	}

--- a/server/ctrlsubsonic/handlers_raw.go
+++ b/server/ctrlsubsonic/handlers_raw.go
@@ -237,7 +237,7 @@ func (c *Controller) ServeStream(w http.ResponseWriter, r *http.Request) *spec.R
 
 		cacheFile, err := os.Stat(path)
 		if err != nil {
-			return fmt.Errorf("failed to stat cache file `%s`: %v", path, err)
+			return fmt.Errorf("failed to stat cache file `%s`: %w", path, err)
 		}
 		contentLength := fmt.Sprintf("%d", cacheFile.Size())
 		w.Header().Set("Content-Length", contentLength)


### PR DESCRIPTION
This PR adds a simple MIME-type guessing logic to `onCacheHit` and `onCacheMiss` handlers, which sets `Content-Type` HTTP response header based on format specified by transcoding profile. It also sets `Content-Length` header, but only on cache hit (as we can't reliably know response length on cache miss, because VBR is a thing).