### PR TITLE
feat(encode): rework encoding profiles to use true VBR and add optional upsample support

### DIFF
--- a/server/encode/encode.go
+++ b/server/encode/encode.go
@@ -41,9 +41,9 @@ func Profiles() map[string]Profile {
 	return map[string]Profile{
 		"mp3":      {"mp3", 128, []string{"-c:a", "libmp3lame"}, false, false, false},
 		"mp3_rg":   {"mp3", 128, []string{"-c:a", "libmp3lame"}, true, false, false},
-		"opus":     {"opus", 96, []string{"-c:a", "libopus", "-vbr", "constrained"}, false, false, false},
-		"opus_rg":  {"opus", 96, []string{"-c:a", "libopus", "-vbr", "constrained"}, true, false, false},
-		"opus_car": {"opus", 96, []string{"-c:a", "libopus", "-vbr", "constrained"}, true, true, true},
+		"opus":     {"opus", 96, []string{"-c:a", "libopus", "-vbr", "on"}, false, false, false},
+		"opus_rg":  {"opus", 96, []string{"-c:a", "libopus", "-vbr", "on"}, true, false, false},
+		"opus_car": {"opus", 96, []string{"-c:a", "libopus", "-vbr", "on"}, true, true, true},
 	}
 }
 


### PR DESCRIPTION
Opus encoder currently uses contstrained VBR, which seems to limit its efficiency in most cases. This PR switches Opus profiles to unconstrained VBR and also adds few tiny additions (see in-code comments for details).