### PR TITLE
adjust artist by tags to hunt for artist cover

### DIFF
--- a/server/ctrlsubsonic/handlers_by_tags.go
+++ b/server/ctrlsubsonic/handlers_by_tags.go
@@ -44,7 +44,7 @@ func (c *Controller) ServeGetArtists(r *http.Request) *spec.Response {
 			resp = append(resp, indexMap[key])
 		}
 		indexMap[key].Artists = append(indexMap[key].Artists,
-			spec.NewArtistByTags(artist))
+			spec.NewArtistByTags(artist, c.DB))
 	}
 	sub := spec.NewResponse()
 	sub.Artists = &spec.Artists{
@@ -69,7 +69,7 @@ func (c *Controller) ServeGetArtist(r *http.Request) *spec.Response {
 		}).
 		First(artist, id.Value)
 	sub := spec.NewResponse()
-	sub.Artist = spec.NewArtistByTags(artist)
+	sub.Artist = spec.NewArtistByTags(artist, c.DB)
 	sub.Artist.Albums = make([]*spec.Album, len(artist.Albums))
 	for i, album := range artist.Albums {
 		sub.Artist.Albums[i] = spec.NewAlbumByTags(album, artist)
@@ -200,7 +200,7 @@ func (c *Controller) ServeSearchThree(r *http.Request) *spec.Response {
 		return spec.NewError(0, "find artists: %v", err)
 	}
 	for _, a := range artists {
-		results.Artists = append(results.Artists, spec.NewArtistByTags(a))
+		results.Artists = append(results.Artists, spec.NewArtistByTags(a, c.DB))
 	}
 
 	// search "albums"

--- a/server/ctrlsubsonic/handlers_raw.go
+++ b/server/ctrlsubsonic/handlers_raw.go
@@ -78,6 +78,8 @@ func coverGetPath(dbc *db.DB, podcastPath string, id specid.ID) (string, error) 
 	switch id.Type {
 	case specid.Album:
 		return coverGetPathAlbum(dbc, id.Value)
+	case specid.Artist:
+		return coverGetPathArtist(dbc, id.Value)
 	case specid.Podcast:
 		return coverGetPathPodcast(dbc, podcastPath, id.Value)
 	case specid.PodcastEpisode:
@@ -93,6 +95,29 @@ func coverGetPathAlbum(dbc *db.DB, id int) (string, error) {
 		Preload("Parent").
 		Select("id, root_dir, left_path, right_path, cover").
 		First(folder, id).
+		Error
+	if err != nil {
+		return "", fmt.Errorf("select album: %w", err)
+	}
+	if folder.Cover == "" {
+		return "", errCoverEmpty
+	}
+	return path.Join(
+		folder.RootDir,
+		folder.LeftPath,
+		folder.RightPath,
+		folder.Cover,
+	), nil
+}
+
+func coverGetPathArtist(dbc *db.DB, id int) (string, error) {
+	folder := &db.Album{}
+	err := dbc.DB.
+		Select("parent.*").
+		Joins("JOIN albums parent ON parent.id=albums.parent_id").
+		// Where("albums.tag_artist_id=?", id.Value).
+		Where("albums.tag_artist_id=?", id).
+		Find(&folder).
 		Error
 	if err != nil {
 		return "", fmt.Errorf("select album: %w", err)

--- a/server/ctrlsubsonic/spec/construct_by_tags.go
+++ b/server/ctrlsubsonic/spec/construct_by_tags.go
@@ -89,12 +89,12 @@ func NewArtistByTags(a *db.Artist, dbc *db.DB) *Artist {
 			AlbumCount: a.AlbumCount,
 			CoverID:    a.SID(),
 		}
-	} else {
-		return &Artist{
-			ID:         a.SID(),
-			Name:       a.Name,
-			AlbumCount: a.AlbumCount,
-		}
+	}
+
+	return &Artist{
+		ID:         a.SID(),
+		Name:       a.Name,
+		AlbumCount: a.AlbumCount,
 	}
 
 }

--- a/server/ctrlsubsonic/spec/construct_by_tags.go
+++ b/server/ctrlsubsonic/spec/construct_by_tags.go
@@ -71,12 +71,32 @@ func NewTrackByTags(t *db.Track, album *db.Album) *TrackChild {
 	return ret
 }
 
-func NewArtistByTags(a *db.Artist) *Artist {
-	return &Artist{
-		ID:         a.SID(),
-		Name:       a.Name,
-		AlbumCount: a.AlbumCount,
+func NewArtistByTags(a *db.Artist, dbc *db.DB) *Artist {
+	// attempt to fetch a cover if possible
+	guessedArtistFolder := &db.Album{}
+	_ = dbc.
+		Select("parent.*").
+		Joins("JOIN albums parent ON parent.id=albums.parent_id").
+		// Where("albums.tag_artist_id=?", id.Value).
+		Where("albums.tag_artist_id=?", a.ID).
+		Find(&guessedArtistFolder).
+		Error
+
+	if guessedArtistFolder.Cover != "" {
+		return &Artist{
+			ID:         a.SID(),
+			Name:       a.Name,
+			AlbumCount: a.AlbumCount,
+			CoverID:    a.SID(),
+		}
+	} else {
+		return &Artist{
+			ID:         a.SID(),
+			Name:       a.Name,
+			AlbumCount: a.AlbumCount,
+		}
 	}
+
 }
 
 func NewGenre(g *db.Genre) *Genre {


### PR DESCRIPTION
For #179 

Propagate the logic we've used for artist covers into other endpoints. This should cover `getArtsits` `getArtist` and `ServeSearchThree` now as well.

Only displays a cover art tag if we have it locally.

I believe when the rebase took place `coverGetPathArtist` didn't make it into the merge as well, so I've corrected that.
