### PR TITLE
Feat/get similar songs 2, Feat/get similar songs, Feat/get top songs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ gonic
 gonicscan
 gonicembed
 .vscode
+*.swp

--- a/server/ctrlsubsonic/spec/spec.go
+++ b/server/ctrlsubsonic/spec/spec.go
@@ -47,6 +47,7 @@ type Response struct {
 	Bookmarks         *Bookmarks         `xml:"bookmarks"         json:"bookmarks,omitempty"`
 	Starred           *Starred           `xml:"starred"           json:"starred,omitempty"`
 	StarredTwo        *StarredTwo        `xml:"starred2"          json:"starred2,omitempty"`
+	TopSongs          *TopSongs          `xml:"topSongs" json:"topSongs", omitempty`
 }
 
 func NewResponse() *Response {
@@ -351,4 +352,8 @@ type StarredTwo struct {
 	Artists []*Artist     `xml:"artist,omitempty" json:"artist,omitempty"`
 	Albums  []*Album      `xml:"album,omitempty"  json:"album,omitempty"`
 	Tracks  []*TrackChild `xml:"song,omitempty"   json:"song,omitempty"`
+}
+
+type TopSongs struct {
+	Tracks []*TrackChild `xml:"song,omitempty"         json:"song,omitempty"`
 }

--- a/server/ctrlsubsonic/spec/spec.go
+++ b/server/ctrlsubsonic/spec/spec.go
@@ -49,6 +49,7 @@ type Response struct {
 	StarredTwo        *StarredTwo        `xml:"starred2"          json:"starred2,omitempty"`
 	TopSongs          *TopSongs          `xml:"topSongs" json:"topSongs,omitempty"`
 	SimilarSongs      *SimilarSongs      `xml:"similarSongs" json:"similarSongs,omitempty"`
+	SimilarSongsTwo   *SimilarSongsTwo   `xml:"similarSongs2" json:"similarSongs2,omitempty"`
 }
 
 func NewResponse() *Response {
@@ -358,6 +359,11 @@ type StarredTwo struct {
 type TopSongs struct {
 	Tracks []*TrackChild `xml:"song,omitempty"         json:"song,omitempty"`
 }
+
 type SimilarSongs struct {
+	Tracks []*TrackChild `xml:"song,omitempty"         json:"song,omitempty"`
+}
+
+type SimilarSongsTwo struct {
 	Tracks []*TrackChild `xml:"song,omitempty"         json:"song,omitempty"`
 }

--- a/server/ctrlsubsonic/spec/spec.go
+++ b/server/ctrlsubsonic/spec/spec.go
@@ -47,7 +47,8 @@ type Response struct {
 	Bookmarks         *Bookmarks         `xml:"bookmarks"         json:"bookmarks,omitempty"`
 	Starred           *Starred           `xml:"starred"           json:"starred,omitempty"`
 	StarredTwo        *StarredTwo        `xml:"starred2"          json:"starred2,omitempty"`
-	TopSongs          *TopSongs          `xml:"topSongs" json:"topSongs", omitempty`
+	TopSongs          *TopSongs          `xml:"topSongs" json:"topSongs,omitempty"`
+	SimilarSongs      *SimilarSongs      `xml:"similarSongs" json:"similarSongs,omitempty"`
 }
 
 func NewResponse() *Response {
@@ -355,5 +356,8 @@ type StarredTwo struct {
 }
 
 type TopSongs struct {
+	Tracks []*TrackChild `xml:"song,omitempty"         json:"song,omitempty"`
+}
+type SimilarSongs struct {
 	Tracks []*TrackChild `xml:"song,omitempty"         json:"song,omitempty"`
 }

--- a/server/scrobble/lastfm/lastfm.go
+++ b/server/scrobble/lastfm/lastfm.go
@@ -25,12 +25,13 @@ var (
 )
 
 type LastFM struct {
-	XMLName   xml.Name  `xml:"lfm"`
-	Status    string    `xml:"status,attr"`
-	Session   Session   `xml:"session"`
-	Error     Error     `xml:"error"`
-	Artist    Artist    `xml:"artist"`
-	TopTracks TopTracks `xml:"toptracks"`
+	XMLName       xml.Name      `xml:"lfm"`
+	Status        string        `xml:"status,attr"`
+	Session       Session       `xml:"session"`
+	Error         Error         `xml:"error"`
+	Artist        Artist        `xml:"artist"`
+	TopTracks     TopTracks     `xml:"toptracks"`
+	SimilarTracks SimilarTracks `xml:"similartracks"`
 }
 
 type Session struct {
@@ -81,6 +82,13 @@ type ArtistBio struct {
 type TopTracks struct {
 	XMLName xml.Name `xml:toptracks`
 	Artist  string   `xml:"artist,attr"`
+	Tracks  []Track  `xml:"track"`
+}
+
+type SimilarTracks struct {
+	XMLName xml.Name `xml:"similartracks"`
+	Artist  string   `xml:"artist,attr"`
+	Track   string   `xml:"track,attr"`
 	Tracks  []Track  `xml:"track"`
 }
 
@@ -156,6 +164,21 @@ func ArtistGetTopTracks(apiKey, artistName string) (TopTracks, error) {
 		return TopTracks{}, fmt.Errorf("making track GET: %w", err)
 	}
 	return resp.TopTracks, nil
+}
+
+func TrackGetSimilarTracks(apiKey string, track *db.Track) (SimilarTracks, error) {
+	params := url.Values{}
+	params.Add("method", "track.getSimilar")
+	params.Add("api_key", apiKey)
+	params.Add("track", track.TagTitle)
+	params.Add("artist", track.Artist.Name)
+
+	resp, err := makeRequest("GET", params)
+	if err != nil {
+		return SimilarTracks{}, fmt.Errorf("making track GET: %s %s %w", track.TagTitle, track.Artist.Name, err)
+	}
+
+	return resp.SimilarTracks, nil
 }
 
 func GetSession(apiKey, secret, token string) (string, error) {

--- a/server/scrobble/lastfm/lastfm.go
+++ b/server/scrobble/lastfm/lastfm.go
@@ -185,16 +185,16 @@ func ArtistGetTopTracks(apiKey, artistName string) (TopTracks, error) {
 	return resp.TopTracks, nil
 }
 
-func TrackGetSimilarTracks(apiKey string, track *db.Track) (SimilarTracks, error) {
+func TrackGetSimilarTracks(apiKey, artistName, trackTitle string) (SimilarTracks, error) {
 	params := url.Values{}
 	params.Add("method", "track.getSimilar")
 	params.Add("api_key", apiKey)
-	params.Add("track", track.TagTitle)
-	params.Add("artist", track.Artist.Name)
+	params.Add("track", trackTitle)
+	params.Add("artist", artistName)
 
 	resp, err := makeRequest("GET", params)
 	if err != nil {
-		return SimilarTracks{}, fmt.Errorf("making track GET: %s %s %w", track.TagTitle, track.Artist.Name, err)
+		return SimilarTracks{}, fmt.Errorf("making track GET: %s %s %w", trackTitle, artistName, err)
 	}
 
 	return resp.SimilarTracks, nil

--- a/server/scrobble/lastfm/lastfm.go
+++ b/server/scrobble/lastfm/lastfm.go
@@ -25,13 +25,14 @@ var (
 )
 
 type LastFM struct {
-	XMLName       xml.Name      `xml:"lfm"`
-	Status        string        `xml:"status,attr"`
-	Session       Session       `xml:"session"`
-	Error         Error         `xml:"error"`
-	Artist        Artist        `xml:"artist"`
-	TopTracks     TopTracks     `xml:"toptracks"`
-	SimilarTracks SimilarTracks `xml:"similartracks"`
+	XMLName        xml.Name       `xml:"lfm"`
+	Status         string         `xml:"status,attr"`
+	Session        Session        `xml:"session"`
+	Error          Error          `xml:"error"`
+	Artist         Artist         `xml:"artist"`
+	TopTracks      TopTracks      `xml:"toptracks"`
+	SimilarTracks  SimilarTracks  `xml:"similartracks"`
+	SimilarArtists SimilarArtists `xml:"similarartists"`
 }
 
 type Session struct {
@@ -43,6 +44,18 @@ type Session struct {
 type Error struct {
 	Code  uint   `xml:"code,attr"`
 	Value string `xml:",chardata"`
+}
+
+type SimilarArtist struct {
+	XMLName xml.Name `xml:"artist"`
+	Name    string   `xml:"name"`
+	MBID    string   `xml:"mbid"`
+	URL     string   `xml:"url"`
+	Image   []struct {
+		Text string `xml:",chardata"`
+		Size string `xml:"size,attr"`
+	} `xml:"image"`
+	Streamable string `xml:"streamable"`
 }
 
 type Artist struct {
@@ -90,6 +103,12 @@ type SimilarTracks struct {
 	Artist  string   `xml:"artist,attr"`
 	Track   string   `xml:"track,attr"`
 	Tracks  []Track  `xml:"track"`
+}
+
+type SimilarArtists struct {
+	XMLName xml.Name `xml:"similarartists"`
+	Artist  string   `xml:"artist,attr"`
+	Artists []Artist `xml:"artist"`
 }
 
 type Track struct {
@@ -179,6 +198,20 @@ func TrackGetSimilarTracks(apiKey string, track *db.Track) (SimilarTracks, error
 	}
 
 	return resp.SimilarTracks, nil
+}
+
+func ArtistGetSimilar(apiKey string, artist *db.Artist) (SimilarArtists, error) {
+	params := url.Values{}
+	params.Add("method", "artist.getSimilar")
+	params.Add("api_key", apiKey)
+	params.Add("artist", artist.Name)
+
+	resp, err := makeRequest("GET", params)
+	if err != nil {
+		return SimilarArtists{}, fmt.Errorf("making similar artists GET:  %w", err)
+	}
+
+	return resp.SimilarArtists, nil
 }
 
 func GetSession(apiKey, secret, token string) (string, error) {

--- a/server/scrobble/lastfm/lastfm.go
+++ b/server/scrobble/lastfm/lastfm.go
@@ -200,11 +200,11 @@ func TrackGetSimilarTracks(apiKey string, track *db.Track) (SimilarTracks, error
 	return resp.SimilarTracks, nil
 }
 
-func ArtistGetSimilar(apiKey string, artist *db.Artist) (SimilarArtists, error) {
+func ArtistGetSimilar(apiKey, artistName string) (SimilarArtists, error) {
 	params := url.Values{}
 	params.Add("method", "artist.getSimilar")
 	params.Add("api_key", apiKey)
-	params.Add("artist", artist.Name)
+	params.Add("artist", artistName)
 
 	resp, err := makeRequest("GET", params)
 	if err != nil {

--- a/server/scrobble/lastfm/lastfm.go
+++ b/server/scrobble/lastfm/lastfm.go
@@ -25,11 +25,12 @@ var (
 )
 
 type LastFM struct {
-	XMLName xml.Name `xml:"lfm"`
-	Status  string   `xml:"status,attr"`
-	Session Session  `xml:"session"`
-	Error   Error    `xml:"error"`
-	Artist  Artist   `xml:"artist"`
+	XMLName   xml.Name  `xml:"lfm"`
+	Status    string    `xml:"status,attr"`
+	Session   Session   `xml:"session"`
+	Error     Error     `xml:"error"`
+	Artist    Artist    `xml:"artist"`
+	TopTracks TopTracks `xml:"toptracks"`
 }
 
 type Session struct {
@@ -75,6 +76,26 @@ type ArtistBio struct {
 	Published string `xml:"published"`
 	Summary   string `xml:"summary"`
 	Content   string `xml:"content"`
+}
+
+type TopTracks struct {
+	XMLName xml.Name `xml:toptracks`
+	Artist  string   `xml:"artist,attr"`
+	Tracks  []Track  `xml:"track"`
+}
+
+type Track struct {
+	Rank      int     `xml:"rank,attr"`
+	Tracks    []Track `xml:"track"`
+	Name      string  `xml:"name"`
+	MBID      string  `xml:"mbid"`
+	PlayCount int     `xml:"playcount"`
+	Listeners int     `xml:"listeners"`
+	URL       string  `xml:"url"`
+	Image     []struct {
+		Text string `xml:",chardata"`
+		Size string `xml:"size,attr"`
+	} `xml:"image"`
 }
 
 func getParamSignature(params url.Values, secret string) string {
@@ -123,6 +144,18 @@ func ArtistGetInfo(apiKey string, artist *db.Artist) (Artist, error) {
 		return Artist{}, fmt.Errorf("making artist GET: %w", err)
 	}
 	return resp.Artist, nil
+}
+
+func ArtistGetTopTracks(apiKey, artistName string) (TopTracks, error) {
+	params := url.Values{}
+	params.Add("method", "artist.getTopTracks")
+	params.Add("api_key", apiKey)
+	params.Add("artist", artistName)
+	resp, err := makeRequest("GET", params)
+	if err != nil {
+		return TopTracks{}, fmt.Errorf("making track GET: %w", err)
+	}
+	return resp.TopTracks, nil
 }
 
 func GetSession(apiKey, secret, token string) (string, error) {

--- a/server/server.go
+++ b/server/server.go
@@ -219,6 +219,7 @@ func setupSubsonic(r *mux.Router, ctrl *ctrlsubsonic.Controller) {
 	r.Handle("/deleteBookmark{_:(?:\\.view)?}", ctrl.H(ctrl.ServeDeleteBookmark))
 	r.Handle("/getTopSongs{_:(?:\\.view)?}", ctrl.H(ctrl.ServeGetTopSongs))
 	r.Handle("/getSimilarSongs{_:(?:\\.view)?}", ctrl.H(ctrl.ServeGetSimilarSongs))
+	r.Handle("/getSimilarSongs2{_:(?:\\.view)?}", ctrl.H(ctrl.ServeGetSimilarSongsTwo))
 
 	// raw
 	r.Handle("/download{_:(?:\\.view)?}", ctrl.HR(ctrl.ServeDownload))

--- a/server/server.go
+++ b/server/server.go
@@ -218,6 +218,7 @@ func setupSubsonic(r *mux.Router, ctrl *ctrlsubsonic.Controller) {
 	r.Handle("/createBookmark{_:(?:\\.view)?}", ctrl.H(ctrl.ServeCreateBookmark))
 	r.Handle("/deleteBookmark{_:(?:\\.view)?}", ctrl.H(ctrl.ServeDeleteBookmark))
 	r.Handle("/getTopSongs{_:(?:\\.view)?}", ctrl.H(ctrl.ServeGetTopSongs))
+	r.Handle("/getSimilarSongs{_:(?:\\.view)?}", ctrl.H(ctrl.ServeGetSimilarSongs))
 
 	// raw
 	r.Handle("/download{_:(?:\\.view)?}", ctrl.HR(ctrl.ServeDownload))

--- a/server/server.go
+++ b/server/server.go
@@ -217,6 +217,7 @@ func setupSubsonic(r *mux.Router, ctrl *ctrlsubsonic.Controller) {
 	r.Handle("/getBookmarks{_:(?:\\.view)?}", ctrl.H(ctrl.ServeGetBookmarks))
 	r.Handle("/createBookmark{_:(?:\\.view)?}", ctrl.H(ctrl.ServeCreateBookmark))
 	r.Handle("/deleteBookmark{_:(?:\\.view)?}", ctrl.H(ctrl.ServeDeleteBookmark))
+	r.Handle("/getTopSongs{_:(?:\\.view)?}", ctrl.H(ctrl.ServeGetTopSongs))
 
 	// raw
 	r.Handle("/download{_:(?:\\.view)?}", ctrl.HR(ctrl.ServeDownload))


### PR DESCRIPTION
Implementation of subsonic [getSimilarSongs2](www.subsonic.org/pages/api.jsp#getSimilarSongs2) and Last.fm [artist.getSimilar](https://www.last.fm/api/show/artist.getSimilar)

N.B. I inspired myself of [ampache](https://github.com/ampache/ampache/) 's implementation `src/Module/Api/Subsonic_Api.php:2229` as Last.Fm doesn't expose such endpoint.

The logic is the following:

1. Retrieve artist 's similar artists using Last.fm 's artist.getSimilar
2. Look in our database for tracks matching the similar artists
3. Randomize (then trim) the track set to prevent ending up with X track of the same artist. 

What do you think about this approach? 