### PR TITLE
Support public playlists

### DIFF
--- a/server/db/migrations.go
+++ b/server/db/migrations.go
@@ -40,6 +40,7 @@ func (db *DB) Migrate(ctx MigrationContext) error {
 		construct(ctx, "202201042236", migrateArtistGuessedFolder),
 		construct(ctx, "202202092013", migrateArtistCover),
 		construct(ctx, "202202121809", migrateAlbumRootDirAgain),
+		construct(ctx, "202202241218", migratePublicPlaylist),
 	}
 
 	return gormigrate.
@@ -326,4 +327,12 @@ func migrateArtistCover(tx *gorm.DB, ctx MigrationContext) error {
 // there was an issue with that migration, try it again since it's updated
 func migrateAlbumRootDirAgain(tx *gorm.DB, ctx MigrationContext) error {
 	return migrateAlbumRootDir(tx, ctx)
+}
+
+func migratePublicPlaylist(tx *gorm.DB, ctx MigrationContext) error {
+	if err := tx.AutoMigrate(Playlist{}).Error; err != nil {
+		return fmt.Errorf("step auto migrate: %w", err)
+	}
+
+	return nil
 }

--- a/server/db/model.go
+++ b/server/db/model.go
@@ -247,6 +247,7 @@ type Playlist struct {
 	Comment    string
 	TrackCount int
 	Items      string
+	IsPublic   bool `sql:"default: null"`
 }
 
 func (p *Playlist) GetItems() []int {


### PR DESCRIPTION
When multiple people share the same instance, they might want to share
their playlists between them.

This allows people to mark playlists as public, and to listen to public
playlists from other people. Listeners will also know who owns the
playlist, to help avoid confusion and make this feature a bit nicer.

Subsonic restrict updating playlists only to owners, this honors that
behavior, but adding flexibility could be achieved easily.