### PR TITLE
Add a ping endpoint that doesn't create a session

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -140,6 +140,9 @@ func setupMisc(r *mux.Router, ctrl *ctrlbase.Controller) {
 		restScan := ctrl.Path(fmt.Sprintf("/rest/startScan.view?%s", r.URL.Query().Encode()))
 		http.Redirect(w, r, restScan, http.StatusSeeOther)
 	})
+	r.HandleFunc("/ping", func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprint(w, "OK")
+	})
 }
 
 func setupAdmin(r *mux.Router, ctrl *ctrladmin.Controller) {


### PR DESCRIPTION
I'm trying to reduce idle disk activity on my install, and so I want to configure my loadbalancer to check an endpoint that doesn't trigger a new session creation in the database.