### PR TITLE
update musicbrainz metadata

### DIFF
--- a/db/model.go
+++ b/db/model.go
@@ -79,25 +79,27 @@ type AudioFile interface {
 }
 
 type Track struct {
-	ID             int `gorm:"primary_key"`
-	CreatedAt      time.Time
-	UpdatedAt      time.Time
-	Filename       string `gorm:"not null; unique_index:idx_folder_filename" sql:"default: null"`
-	FilenameUDec   string `sql:"default: null"`
-	Album          *Album
-	AlbumID        int `gorm:"not null; unique_index:idx_folder_filename" sql:"default: null; type:int REFERENCES albums(id) ON DELETE CASCADE"`
-	Artist         *Artist
-	ArtistID       int      `gorm:"not null" sql:"default: null; type:int REFERENCES artists(id) ON DELETE CASCADE"`
-	Genres         []*Genre `gorm:"many2many:track_genres"`
-	Size           int      `sql:"default: null"`
-	Length         int      `sql:"default: null"`
-	Bitrate        int      `sql:"default: null"`
-	TagTitle       string   `sql:"default: null"`
-	TagTitleUDec   string   `sql:"default: null"`
-	TagTrackArtist string   `sql:"default: null"`
-	TagTrackNumber int      `sql:"default: null"`
-	TagDiscNumber  int      `sql:"default: null"`
-	TagBrainzID    string   `sql:"default: null"`
+	ID                   int `gorm:"primary_key"`
+	CreatedAt            time.Time
+	UpdatedAt            time.Time
+	Filename             string `gorm:"not null; unique_index:idx_folder_filename" sql:"default: null"`
+	FilenameUDec         string `sql:"default: null"`
+	Album                *Album
+	AlbumID              int `gorm:"not null; unique_index:idx_folder_filename" sql:"default: null; type:int REFERENCES albums(id) ON DELETE CASCADE"`
+	Artist               *Artist
+	ArtistID             int      `gorm:"not null" sql:"default: null; type:int REFERENCES artists(id) ON DELETE CASCADE"`
+	Genres               []*Genre `gorm:"many2many:track_genres"`
+	Size                 int      `sql:"default: null"`
+	Length               int      `sql:"default: null"`
+	Bitrate              int      `sql:"default: null"`
+	TagTitle             string   `sql:"default: null"`
+	TagTitleUDec         string   `sql:"default: null"`
+	TagTrackArtist       string   `sql:"default: null"`
+	TagTrackNumber       int      `sql:"default: null"`
+	TagDiscNumber        int      `sql:"default: null"`
+	TagBrainzRecordingID string   `sql:"default: null"`
+	TagBrainzReleaseID   string   `sql:"default: null"`
+	TagBrainzTrackID     string   `sql:"default: null"`
 }
 
 func (t *Track) AudioLength() int  { return t.Length }

--- a/scanner/scanner.go
+++ b/scanner/scanner.go
@@ -302,7 +302,9 @@ func populateTrack(tx *db.DB, album *db.Album, track *db.Track, trags tags.Parse
 	track.TagTrackArtist = trags.Artist()
 	track.TagTrackNumber = trags.TrackNumber()
 	track.TagDiscNumber = trags.DiscNumber()
-	track.TagBrainzID = trags.BrainzID()
+	track.TagBrainzRecordingID = trags.RecordingID()
+	track.TagBrainzTrackID = trags.TrackID()
+	track.TagBrainzReleaseID = trags.AlbumBrainzID()
 
 	track.Length = trags.Length()   // these two should be calculated
 	track.Bitrate = trags.Bitrate() // ...from the file instead of tags

--- a/scanner/tags/tags.go
+++ b/scanner/tags/tags.go
@@ -38,7 +38,8 @@ func (t *Tagger) firstInt(sep string, keys ...string) int {
 }
 
 func (t *Tagger) Title() string         { return t.first("title") }
-func (t *Tagger) BrainzID() string      { return t.first("musicbrainz_trackid") }
+func (t *Tagger) RecordingID() string   { return t.first("musicbrainz_trackid") }
+func (t *Tagger) TrackID() string       { return t.first("musicbrainz_releasetrackid") }
 func (t *Tagger) Artist() string        { return t.first("artist") }
 func (t *Tagger) Album() string         { return t.first("album") }
 func (t *Tagger) AlbumArtist() string   { return t.first("albumartist", "album artist") }
@@ -63,7 +64,8 @@ type Reader interface {
 
 type Parser interface {
 	Title() string
-	BrainzID() string
+	RecordingID() string
+	TrackID() string
 	Artist() string
 	Album() string
 	AlbumArtist() string

--- a/scrobble/lastfm/lastfm.go
+++ b/scrobble/lastfm/lastfm.go
@@ -260,7 +260,7 @@ func (s *Scrobbler) Scrobble(user *db.User, track *db.Track, stamp time.Time, su
 	params.Add("track", track.TagTitle)
 	params.Add("trackNumber", strconv.Itoa(track.TagTrackNumber))
 	params.Add("album", track.Album.TagTitle)
-	params.Add("mbid", track.TagBrainzID)
+	params.Add("mbid", track.TagBrainzTrackID)
 	params.Add("albumArtist", track.Artist.Name)
 	params.Add("duration", strconv.Itoa(track.Length))
 	params.Add("api_sig", getParamSignature(params, secret))

--- a/scrobble/listenbrainz/listenbrainz.go
+++ b/scrobble/listenbrainz/listenbrainz.go
@@ -27,9 +27,11 @@ var (
 )
 
 type AdditionalInfo struct {
-	TrackNumber int    `json:"tracknumber,omitempty"`
-	TrackMBID   string `json:"track_mbid,omitempty"`
-	TrackLength int    `json:"track_length,omitempty"`
+	TrackNumber   int    `json:"tracknumber,omitempty"`
+	TrackMBID     string `json:"track_mbid,omitempty"`
+	RecordingMBID string `json:"recording_mbid,omitempty"`
+	ReleaseMBID   string `json:"release_mbid,omitempty"`
+	TrackLength   int    `json:"track_length,omitempty"`
 }
 
 type TrackMetadata struct {
@@ -58,9 +60,11 @@ func (s *Scrobbler) Scrobble(user *db.User, track *db.Track, stamp time.Time, su
 	payload := &Payload{
 		TrackMetadata: &TrackMetadata{
 			AdditionalInfo: &AdditionalInfo{
-				TrackNumber: track.TagTrackNumber,
-				TrackMBID:   track.TagBrainzID,
-				TrackLength: track.Length,
+				TrackNumber:   track.TagTrackNumber,
+				TrackMBID:     track.TagBrainzTrackID,
+				RecordingMBID: track.TagBrainzRecordingID,
+				ReleaseMBID:   track.TagBrainzReleaseID,
+				TrackLength:   track.Length,
 			},
 			ArtistName:  track.TagTrackArtist,
 			TrackName:   track.TagTitle,


### PR DESCRIPTION
Currently, the musicbrainz scrobbler is submitting incorrect data. The mappings for this api can be found [here](https://picard-docs.musicbrainz.org/downloads/MusicBrainz_Picard_Tag_Map.html):

```
Json Field      : MusicBrainz Internal Name	: Metadata Tag Name

release_mbid	: musicbrainz_releaseid		: musicbrainz_albumid
recording_mbid	: musicbrainz_recordingid	: musicbrainz_trackid
track_mbid	: musicbrainz_trackid		: musicbrainz_releasetrackid

```


Gonic submits the metadata tag `musicbrainz_trackid` (https://github.com/sentriz/gonic/blob/master/scanner/tags/tags.go#L41) as `track_mbid` (https://github.com/sentriz/gonic/blob/master/scrobble/listenbrainz/listenbrainz.go#L62). But that field actually corresponds to `musicbrainz_recordingid`.  The correct metadata field to use is `musicbrainz_releasetrackid`.

This PR corrects this and adds two more entries in the AdditionalInfo
struct, `RecordingMBID` and `ReleaseMBID`. Reflecting the mapping above.