### PR TITLE
Fix the file extension when transcoding

### DIFF
--- a/server/ctrlsubsonic/handlers_by_folder.go
+++ b/server/ctrlsubsonic/handlers_by_folder.go
@@ -98,7 +98,7 @@ func (c *Controller) ServeGetMusicDirectory(r *http.Request) *spec.Response {
 		Order("filename").
 		Find(&childTracks)
 
-	//Get the transcoder profile to serve the transcoded MIME type and Suffix
+	// Get the transcoder profile to serve the transcoded MIME type and Suffix
 	var transcodeMIME = ""
 	var transcodeSuffix = ""
 	var transcodeOk = false
@@ -283,7 +283,7 @@ func (c *Controller) ServeSearchTwo(r *http.Request) *spec.Response {
 		return spec.NewError(0, "find tracks: %v", err)
 	}
 
-	//Get the transcoder profile to serve the transcoded MIME type and Suffix
+	// Get the transcoder profile to serve the transcoded MIME type and Suffix
 	var transcodeMIME = ""
 	var transcodeSuffix = ""
 	var transcodeOk = false
@@ -381,7 +381,7 @@ func (c *Controller) ServeGetStarred(r *http.Request) *spec.Response {
 		return spec.NewError(0, "find tracks: %v", err)
 	}
 
-	//Get the transcoder profile to serve the transcoded MIME type and Suffix
+	// Get the transcoder profile to serve the transcoded MIME type and Suffix
 	var transcodeMIME = ""
 	var transcodeSuffix = ""
 	var transcodeOk = false

--- a/server/ctrlsubsonic/handlers_by_folder.go
+++ b/server/ctrlsubsonic/handlers_by_folder.go
@@ -105,7 +105,7 @@ func (c *Controller) ServeGetMusicDirectory(r *http.Request) *spec.Response {
 	pref, err := streamGetTransPref(c.DB, user.ID, params.GetOr("c", ""))
 	if err != nil && !errors.Is(err, gorm.ErrRecordNotFound) {
 	        return spec.NewError(0, "couldn't find transcode preference: %v", err)
-	} else {
+	} else if (pref != nil) {
 	        profile, ok := transcode.UserProfiles[pref.Profile]
 	        if ok {
 	                transcodeOk = true
@@ -290,7 +290,7 @@ func (c *Controller) ServeSearchTwo(r *http.Request) *spec.Response {
 	pref, err := streamGetTransPref(c.DB, user.ID, params.GetOr("c", ""))
 	if err != nil && !errors.Is(err, gorm.ErrRecordNotFound) {
 	        return spec.NewError(0, "couldn't find transcode preference: %v", err)
-	} else {
+	} else if (pref != nil) {
 	        profile, ok := transcode.UserProfiles[pref.Profile]
 	        if ok {
 	                transcodeOk = true
@@ -388,7 +388,7 @@ func (c *Controller) ServeGetStarred(r *http.Request) *spec.Response {
 	pref, err := streamGetTransPref(c.DB, user.ID, params.GetOr("c", ""))
 	if err != nil && !errors.Is(err, gorm.ErrRecordNotFound) {
 	        return spec.NewError(0, "couldn't find transcode preference: %v", err)
-	} else {
+	} else if (pref != nil) {
 	        profile, ok := transcode.UserProfiles[pref.Profile]
 	        if ok {
 	                transcodeOk = true

--- a/server/ctrlsubsonic/handlers_by_tags.go
+++ b/server/ctrlsubsonic/handlers_by_tags.go
@@ -119,7 +119,7 @@ func (c *Controller) ServeGetAlbum(r *http.Request) *spec.Response {
 	sub.Album = spec.NewAlbumByTags(album, album.TagArtist)
 	sub.Album.Tracks = make([]*spec.TrackChild, len(album.Tracks))
 
-	//Get the transcoder profile to serve the transcoded MIME type and Suffix
+	// Get the transcoder profile to serve the transcoded MIME type and Suffix
 	var transcodeMIME = ""
 	var transcodeSuffix = ""
 	var transcodeOk = false
@@ -293,7 +293,7 @@ func (c *Controller) ServeSearchThree(r *http.Request) *spec.Response {
 		return spec.NewError(0, "find tracks: %v", err)
 	}
 
-	//Get the transcoder profile to serve the transcoded MIME type and Suffix
+	// Get the transcoder profile to serve the transcoded MIME type and Suffix
 	var transcodeMIME = ""
 	var transcodeSuffix = ""
 	var transcodeOk = false
@@ -457,7 +457,7 @@ func (c *Controller) ServeGetSongsByGenre(r *http.Request) *spec.Response {
 		List: make([]*spec.TrackChild, len(tracks)),
 	}
 
-	//Get the transcoder profile to serve the transcoded MIME type and Suffix
+	// Get the transcoder profile to serve the transcoded MIME type and Suffix
 	var transcodeMIME = ""
 	var transcodeSuffix = ""
 	var transcodeOk = false
@@ -543,7 +543,7 @@ func (c *Controller) ServeGetStarredTwo(r *http.Request) *spec.Response {
 		return spec.NewError(0, "find tracks: %v", err)
 	}
 
-	//Get the transcoder profile to serve the transcoded MIME type and Suffix
+	// Get the transcoder profile to serve the transcoded MIME type and Suffix
 	var transcodeMIME = ""
 	var transcodeSuffix = ""
 	var transcodeOk = false
@@ -638,7 +638,7 @@ func (c *Controller) ServeGetTopSongs(r *http.Request) *spec.Response {
 		Tracks: make([]*spec.TrackChild, len(tracks)),
 	}
 
-	//Get the transcoder profile to serve the transcoded MIME type and Suffix
+	// Get the transcoder profile to serve the transcoded MIME type and Suffix
 	var transcodeMIME = ""
 	var transcodeSuffix = ""
 	var transcodeOk = false
@@ -725,7 +725,7 @@ func (c *Controller) ServeGetSimilarSongs(r *http.Request) *spec.Response {
 		Tracks: make([]*spec.TrackChild, len(tracks)),
 	}
 
-	//Get the transcoder profile to serve the transcoded MIME type and Suffix
+	// Get the transcoder profile to serve the transcoded MIME type and Suffix
 	var transcodeMIME = ""
 	var transcodeSuffix = ""
 	var transcodeOk = false
@@ -810,7 +810,7 @@ func (c *Controller) ServeGetSimilarSongsTwo(r *http.Request) *spec.Response {
 		Tracks: make([]*spec.TrackChild, len(tracks)),
 	}
 
-	//Get the transcoder profile to serve the transcoded MIME type and Suffix
+	// Get the transcoder profile to serve the transcoded MIME type and Suffix
 	var transcodeMIME = ""
 	var transcodeSuffix = ""
 	var transcodeOk = false

--- a/server/ctrlsubsonic/handlers_by_tags.go
+++ b/server/ctrlsubsonic/handlers_by_tags.go
@@ -126,7 +126,7 @@ func (c *Controller) ServeGetAlbum(r *http.Request) *spec.Response {
 	pref, err := streamGetTransPref(c.DB, user.ID, params.GetOr("c", ""))
 	if err != nil && !errors.Is(err, gorm.ErrRecordNotFound) {
 	        return spec.NewError(0, "couldn't find transcode preference: %v", err)
-	} else {
+	} else if (pref != nil) {
 	        profile, ok := transcode.UserProfiles[pref.Profile]
 	        if ok {
 	                transcodeOk = true
@@ -300,7 +300,7 @@ func (c *Controller) ServeSearchThree(r *http.Request) *spec.Response {
 	pref, err := streamGetTransPref(c.DB, user.ID, params.GetOr("c", ""))
 	if err != nil && !errors.Is(err, gorm.ErrRecordNotFound) {
 	        return spec.NewError(0, "couldn't find transcode preference: %v", err)
-	} else {
+	} else if (pref != nil) {
 	        profile, ok := transcode.UserProfiles[pref.Profile]
 	        if ok {
 	                transcodeOk = true
@@ -464,7 +464,7 @@ func (c *Controller) ServeGetSongsByGenre(r *http.Request) *spec.Response {
 	pref, err := streamGetTransPref(c.DB, user.ID, params.GetOr("c", ""))
 	if err != nil && !errors.Is(err, gorm.ErrRecordNotFound) {
 	        return spec.NewError(0, "couldn't find transcode preference: %v", err)
-	} else {
+	} else if (pref != nil) {
 	        profile, ok := transcode.UserProfiles[pref.Profile]
 	        if ok {
 	                transcodeOk = true
@@ -550,7 +550,7 @@ func (c *Controller) ServeGetStarredTwo(r *http.Request) *spec.Response {
 	pref, err := streamGetTransPref(c.DB, user.ID, params.GetOr("c", ""))
 	if err != nil && !errors.Is(err, gorm.ErrRecordNotFound) {
 	        return spec.NewError(0, "couldn't find transcode preference: %v", err)
-	} else {
+	} else if (pref != nil) {
 	        profile, ok := transcode.UserProfiles[pref.Profile]
 	        if ok {
 	                transcodeOk = true
@@ -645,7 +645,7 @@ func (c *Controller) ServeGetTopSongs(r *http.Request) *spec.Response {
 	pref, err := streamGetTransPref(c.DB, user.ID, params.GetOr("c", ""))
 	if err != nil && !errors.Is(err, gorm.ErrRecordNotFound) {
 	        return spec.NewError(0, "couldn't find transcode preference: %v", err)
-	} else {
+	} else if (pref != nil) {
 	        profile, ok := transcode.UserProfiles[pref.Profile]
 	        if ok {
 	                transcodeOk = true
@@ -732,7 +732,7 @@ func (c *Controller) ServeGetSimilarSongs(r *http.Request) *spec.Response {
 	pref, err := streamGetTransPref(c.DB, user.ID, params.GetOr("c", ""))
 	if err != nil && !errors.Is(err, gorm.ErrRecordNotFound) {
 	        return spec.NewError(0, "couldn't find transcode preference: %v", err)
-	} else {
+	} else if (pref != nil) {
 	        profile, ok := transcode.UserProfiles[pref.Profile]
 	        if ok {
 	                transcodeOk = true
@@ -817,7 +817,7 @@ func (c *Controller) ServeGetSimilarSongsTwo(r *http.Request) *spec.Response {
 	pref, err := streamGetTransPref(c.DB, user.ID, params.GetOr("c", ""))
 	if err != nil && !errors.Is(err, gorm.ErrRecordNotFound) {
 	        return spec.NewError(0, "couldn't find transcode preference: %v", err)
-	} else {
+	} else if (pref != nil) {
 	        profile, ok := transcode.UserProfiles[pref.Profile]
 	        if ok {
 	                transcodeOk = true

--- a/server/ctrlsubsonic/handlers_by_tags.go
+++ b/server/ctrlsubsonic/handlers_by_tags.go
@@ -310,7 +310,7 @@ func (c *Controller) ServeSearchThree(r *http.Request) *spec.Response {
 	}
 
 	for _, t := range tracks {
-		var track = spec.NewTCTrackByFolder(t, t.Album)
+		var track = spec.NewTrackByTags(t, t.Album)
 		if transcodeOk {
 			track.TranscodedContentType = transcodeMIME
 			track.TranscodedSuffix = transcodeSuffix

--- a/server/ctrlsubsonic/handlers_common.go
+++ b/server/ctrlsubsonic/handlers_common.go
@@ -147,7 +147,7 @@ func (c *Controller) ServeGetPlayQueue(r *http.Request) *spec.Response {
 	trackIDs := queue.GetItems()
 	sub.PlayQueue.List = make([]*spec.TrackChild, len(trackIDs))
 
-	//Get the transcoder profile to serve the transcoded MIME type and Suffix
+	// Get the transcoder profile to serve the transcoded MIME type and Suffix
 	var transcodeMIME = ""
 	var transcodeSuffix = ""
 	var transcodeOk = false
@@ -264,7 +264,7 @@ func (c *Controller) ServeGetRandomSongs(r *http.Request) *spec.Response {
 	sub.RandomTracks = &spec.RandomTracks{}
 	sub.RandomTracks.List = make([]*spec.TrackChild, len(tracks))
 
-	//Get the transcoder profile to serve the transcoded MIME type and Suffix
+	// Get the transcoder profile to serve the transcoded MIME type and Suffix
 	var transcodeMIME = ""
 	var transcodeSuffix = ""
 	var transcodeOk = false

--- a/server/ctrlsubsonic/handlers_common.go
+++ b/server/ctrlsubsonic/handlers_common.go
@@ -154,7 +154,7 @@ func (c *Controller) ServeGetPlayQueue(r *http.Request) *spec.Response {
 	pref, err := streamGetTransPref(c.DB, user.ID, "")
 	if err != nil && !errors.Is(err, gorm.ErrRecordNotFound) {
 		return spec.NewError(0, "couldn't find transcode preference: %v", err)
-	} else {
+	} else if (pref != nil) {
 		profile, ok := transcode.UserProfiles[pref.Profile]
 		if ok {
 			transcodeOk = true
@@ -271,7 +271,7 @@ func (c *Controller) ServeGetRandomSongs(r *http.Request) *spec.Response {
 	pref, err := streamGetTransPref(c.DB, user.ID, params.GetOr("c", ""))
 	if err != nil && !errors.Is(err, gorm.ErrRecordNotFound) {
 		return spec.NewError(0, "couldn't find transcode preference: %v", err)
-	} else {
+	} else if (pref != nil) {
 		profile, ok := transcode.UserProfiles[pref.Profile]
 		if ok {
 			transcodeMIME = profile.MIME()

--- a/server/ctrlsubsonic/handlers_playlist.go
+++ b/server/ctrlsubsonic/handlers_playlist.go
@@ -30,7 +30,7 @@ func playlistRender(c *Controller, playlist *db.Playlist) *spec.Playlist {
 
 	trackIDs := playlist.GetItems()
 	resp.List = make([]*spec.TrackChild, len(trackIDs))
-	//Get the transcoder profile to serve the transcoded MIME type and Suffix
+	// Get the transcoder profile to serve the transcoded MIME type and Suffix
 	var transcodeMIME = ""
 	var transcodeSuffix = ""
 	var transcodeOk = false

--- a/server/ctrlsubsonic/spec/spec.go
+++ b/server/ctrlsubsonic/spec/spec.go
@@ -135,28 +135,30 @@ type TracksByGenre struct {
 }
 
 type TrackChild struct {
-	ID          *specid.ID `xml:"id,attr,omitempty"          json:"id,omitempty"`
-	Album       string     `xml:"album,attr,omitempty"       json:"album,omitempty"`
-	AlbumID     *specid.ID `xml:"albumId,attr,omitempty"     json:"albumId,omitempty"`
-	Artist      string     `xml:"artist,attr,omitempty"      json:"artist,omitempty"`
-	ArtistID    *specid.ID `xml:"artistId,attr,omitempty"    json:"artistId,omitempty"`
-	Bitrate     int        `xml:"bitRate,attr,omitempty"     json:"bitRate,omitempty"`
-	ContentType string     `xml:"contentType,attr,omitempty" json:"contentType,omitempty"`
-	CoverID     *specid.ID `xml:"coverArt,attr,omitempty"    json:"coverArt,omitempty"`
-	CreatedAt   time.Time  `xml:"created,attr,omitempty"     json:"created,omitempty"`
-	Duration    int        `xml:"duration,attr,omitempty"    json:"duration,omitempty"`
-	Genre       string     `xml:"genre,attr,omitempty"       json:"genre,omitempty"`
-	IsDir       bool       `xml:"isDir,attr"                 json:"isDir"`
-	IsVideo     bool       `xml:"isVideo,attr"               json:"isVideo"`
-	ParentID    *specid.ID `xml:"parent,attr,omitempty"      json:"parent,omitempty"`
-	Path        string     `xml:"path,attr,omitempty"        json:"path,omitempty"`
-	Size        int        `xml:"size,attr,omitempty"        json:"size,omitempty"`
-	Suffix      string     `xml:"suffix,attr,omitempty"      json:"suffix,omitempty"`
-	Title       string     `xml:"title,attr"                 json:"title"`
-	TrackNumber int        `xml:"track,attr,omitempty"       json:"track,omitempty"`
-	DiscNumber  int        `xml:"discNumber,attr,omitempty"  json:"discNumber,omitempty"`
-	Type        string     `xml:"type,attr,omitempty"        json:"type,omitempty"`
-	Year        int        `xml:"year,attr,omitempty"        json:"year,omitempty"`
+	ID                    *specid.ID `xml:"id,attr,omitempty"                    json:"id,omitempty"`
+	Album                 string     `xml:"album,attr,omitempty"                 json:"album,omitempty"`
+	AlbumID               *specid.ID `xml:"albumId,attr,omitempty"               json:"albumId,omitempty"`
+	Artist                string     `xml:"artist,attr,omitempty"                json:"artist,omitempty"`
+	ArtistID              *specid.ID `xml:"artistId,attr,omitempty"              json:"artistId,omitempty"`
+	Bitrate               int        `xml:"bitRate,attr,omitempty"               json:"bitRate,omitempty"`
+	ContentType           string     `xml:"contentType,attr,omitempty"           json:"contentType,omitempty"`
+	TranscodedContentType string     `xml:"transcodedContentType,attr,omitempty" json:"transcodedContentType,omitempty"`
+	CoverID               *specid.ID `xml:"coverArt,attr,omitempty"              json:"coverArt,omitempty"`
+	CreatedAt             time.Time  `xml:"created,attr,omitempty"               json:"created,omitempty"`
+	Duration              int        `xml:"duration,attr,omitempty"              json:"duration,omitempty"`
+	Genre                 string     `xml:"genre,attr,omitempty"                 json:"genre,omitempty"`
+	IsDir                 bool       `xml:"isDir,attr"                           json:"isDir"`
+	IsVideo               bool       `xml:"isVideo,attr"                         json:"isVideo"`
+	ParentID              *specid.ID `xml:"parent,attr,omitempty"                json:"parent,omitempty"`
+	Path                  string     `xml:"path,attr,omitempty"                  json:"path,omitempty"`
+	Size                  int        `xml:"size,attr,omitempty"                  json:"size,omitempty"`
+	Suffix                string     `xml:"suffix,attr,omitempty"                json:"suffix,omitempty"`
+	TranscodedSuffix      string     `xml:"transcodedSuffix,attr,omitempty"      json:"transcodedSuffix,omitempty"`
+	Title                 string     `xml:"title,attr"                           json:"title"`
+	TrackNumber           int        `xml:"track,attr,omitempty"                 json:"track,omitempty"`
+	DiscNumber            int        `xml:"discNumber,attr,omitempty"            json:"discNumber,omitempty"`
+	Type                  string     `xml:"type,attr,omitempty"                  json:"type,omitempty"`
+	Year                  int        `xml:"year,attr,omitempty"                  json:"year,omitempty"`
 	// star / rating
 	Starred       *time.Time `xml:"starred,attr,omitempty"         json:"starred,omitempty"`
 	UserRating    int        `xml:"userRating,attr,omitempty"      json:"userRating,omitempty"`

--- a/transcode/transcode.go
+++ b/transcode/transcode.go
@@ -31,8 +31,8 @@ var UserProfiles = map[string]Profile{
 
 // Store as simple strings, since we may let the user provide their own profiles soon
 var (
-	MP3   = NewProfile("audio/mpeg", 128, `ffmpeg -v 0 -i <file> -ss <seek> -map 0:a:0 -vn -b:a <bitrate> -c:a libmp3lame -af "volume=replaygain=track:replaygain_preamp=6dB:replaygain_noclip=0, alimiter=level=disabled, asidedata=mode=delete:type=REPLAYGAIN" -metadata replaygain_album_gain= -metadata replaygain_album_peak= -metadata replaygain_track_gain= -metadata replaygain_track_peak= -metadata r128_album_gain= -metadata r128_track_gain= -f mp3 -`)
-	MP3RG = NewProfile("audio/mpeg", 128, `ffmpeg -v 0 -i <file> -ss <seek> -map 0:a:0 -vn -b:a <bitrate> -c:a libmp3lame -af "volume=replaygain=track:replaygain_preamp=6dB:replaygain_noclip=0, alimiter=level=disabled, asidedata=mode=delete:type=REPLAYGAIN" -metadata replaygain_album_gain= -metadata replaygain_album_peak= -metadata replaygain_track_gain= -metadata replaygain_track_peak= -metadata r128_album_gain= -metadata r128_track_gain= -f mp3 -`)
+	MP3   = NewProfile("audio/mpeg", "mp3", 128, `ffmpeg -v 0 -i <file> -ss <seek> -map 0:a:0 -vn -b:a <bitrate> -c:a libmp3lame -af "volume=replaygain=track:replaygain_preamp=6dB:replaygain_noclip=0, alimiter=level=disabled, asidedata=mode=delete:type=REPLAYGAIN" -metadata replaygain_album_gain= -metadata replaygain_album_peak= -metadata replaygain_track_gain= -metadata replaygain_track_peak= -metadata r128_album_gain= -metadata r128_track_gain= -f mp3 -`)
+	MP3RG = NewProfile("audio/mpeg", "mp3", 128, `ffmpeg -v 0 -i <file> -ss <seek> -map 0:a:0 -vn -b:a <bitrate> -c:a libmp3lame -af "volume=replaygain=track:replaygain_preamp=6dB:replaygain_noclip=0, alimiter=level=disabled, asidedata=mode=delete:type=REPLAYGAIN" -metadata replaygain_album_gain= -metadata replaygain_album_peak= -metadata replaygain_track_gain= -metadata replaygain_track_peak= -metadata r128_album_gain= -metadata r128_track_gain= -f mp3 -`)
 
 	// this sets a baseline gain which results in the final track being +3~5dB louder than
 	// Foobar2000's default ReplayGain target volume.
@@ -45,14 +45,14 @@ var (
 	// on my Ryzen 3600 to transcode an 8-minute FLAC with 2x upsample and RG applied.
 	//
 	// -- @spijet
-	OpusCar    = NewProfile("audio/ogg", 96, `ffmpeg -v 0 -i <file> -ss <seek> -map 0:a:0 -vn -b:a <bitrate> -c:a libopus -vbr on -af "aresample=96000:resampler=soxr, volume=replaygain=track:replaygain_preamp=15dB:replaygain_noclip=0, alimiter=level=disabled, asidedata=mode=delete:type=REPLAYGAIN" -f opus -`)
-	Opus       = NewProfile("audio/ogg", 96, `ffmpeg -v 0 -i <file> -ss <seek> -map 0:a:0 -vn -b:a <bitrate> -c:a libopus -vbr on -af "volume=replaygain=track:replaygain_preamp=6dB:replaygain_noclip=0, alimiter=level=disabled, asidedata=mode=delete:type=REPLAYGAIN" -metadata replaygain_album_gain= -metadata replaygain_album_peak= -metadata replaygain_track_gain= -metadata replaygain_track_peak= -metadata r128_album_gain= -metadata r128_track_gain= -f opus -`)
-	OpusRG     = NewProfile("audio/ogg", 96, `ffmpeg -v 0 -i <file> -ss <seek> -map 0:a:0 -vn -b:a <bitrate> -c:a libopus -vbr on -af "volume=replaygain=track:replaygain_preamp=6dB:replaygain_noclip=0, alimiter=level=disabled, asidedata=mode=delete:type=REPLAYGAIN" -metadata replaygain_album_gain= -metadata replaygain_album_peak= -metadata replaygain_track_gain= -metadata replaygain_track_peak= -metadata r128_album_gain= -metadata r128_track_gain= -f opus -`)
-	Opus128Car = NewProfile("audio/ogg", 128, `ffmpeg -v 0 -i <file> -ss <seek> -map 0:a:0 -vn -b:a <bitrate> -c:a libopus -vbr on -af "aresample=96000:resampler=soxr, volume=replaygain=track:replaygain_preamp=15dB:replaygain_noclip=0, alimiter=level=disabled, asidedata=mode=delete:type=REPLAYGAIN" -f opus -`)
-	Opus128    = NewProfile("audio/ogg", 128, `ffmpeg -v 0 -i <file> -ss <seek> -map 0:a:0 -vn -b:a <bitrate> -c:a libopus -vbr on -af "volume=replaygain=track:replaygain_preamp=6dB:replaygain_noclip=0, alimiter=level=disabled, asidedata=mode=delete:type=REPLAYGAIN" -metadata replaygain_album_gain= -metadata replaygain_album_peak= -metadata replaygain_track_gain= -metadata replaygain_track_peak= -metadata r128_album_gain= -metadata r128_track_gain= -f opus -`)
-	Opus128RG  = NewProfile("audio/ogg", 128, `ffmpeg -v 0 -i <file> -ss <seek> -map 0:a:0 -vn -b:a <bitrate> -c:a libopus -vbr on -af "volume=replaygain=track:replaygain_preamp=6dB:replaygain_noclip=0, alimiter=level=disabled, asidedata=mode=delete:type=REPLAYGAIN" -metadata replaygain_album_gain= -metadata replaygain_album_peak= -metadata replaygain_track_gain= -metadata replaygain_track_peak= -metadata r128_album_gain= -metadata r128_track_gain= -f opus -`)
+	OpusCar    = NewProfile("audio/ogg", "ogg", 96, `ffmpeg -v 0 -i <file> -ss <seek> -map 0:a:0 -vn -b:a <bitrate> -c:a libopus -vbr on -af "aresample=96000:resampler=soxr, volume=replaygain=track:replaygain_preamp=15dB:replaygain_noclip=0, alimiter=level=disabled, asidedata=mode=delete:type=REPLAYGAIN" -f opus -`)
+	Opus       = NewProfile("audio/ogg", "ogg", 96, `ffmpeg -v 0 -i <file> -ss <seek> -map 0:a:0 -vn -b:a <bitrate> -c:a libopus -vbr on -af "volume=replaygain=track:replaygain_preamp=6dB:replaygain_noclip=0, alimiter=level=disabled, asidedata=mode=delete:type=REPLAYGAIN" -metadata replaygain_album_gain= -metadata replaygain_album_peak= -metadata replaygain_track_gain= -metadata replaygain_track_peak= -metadata r128_album_gain= -metadata r128_track_gain= -f opus -`)
+	OpusRG     = NewProfile("audio/ogg", "ogg", 96, `ffmpeg -v 0 -i <file> -ss <seek> -map 0:a:0 -vn -b:a <bitrate> -c:a libopus -vbr on -af "volume=replaygain=track:replaygain_preamp=6dB:replaygain_noclip=0, alimiter=level=disabled, asidedata=mode=delete:type=REPLAYGAIN" -metadata replaygain_album_gain= -metadata replaygain_album_peak= -metadata replaygain_track_gain= -metadata replaygain_track_peak= -metadata r128_album_gain= -metadata r128_track_gain= -f opus -`)
+	Opus128Car = NewProfile("audio/ogg", "ogg", 128, `ffmpeg -v 0 -i <file> -ss <seek> -map 0:a:0 -vn -b:a <bitrate> -c:a libopus -vbr on -af "aresample=96000:resampler=soxr, volume=replaygain=track:replaygain_preamp=15dB:replaygain_noclip=0, alimiter=level=disabled, asidedata=mode=delete:type=REPLAYGAIN" -f opus -`)
+	Opus128    = NewProfile("audio/ogg", "ogg", 128, `ffmpeg -v 0 -i <file> -ss <seek> -map 0:a:0 -vn -b:a <bitrate> -c:a libopus -vbr on -af "volume=replaygain=track:replaygain_preamp=6dB:replaygain_noclip=0, alimiter=level=disabled, asidedata=mode=delete:type=REPLAYGAIN" -metadata replaygain_album_gain= -metadata replaygain_album_peak= -metadata replaygain_track_gain= -metadata replaygain_track_peak= -metadata r128_album_gain= -metadata r128_track_gain= -f opus -`)
+	Opus128RG  = NewProfile("audio/ogg", "ogg", 128, `ffmpeg -v 0 -i <file> -ss <seek> -map 0:a:0 -vn -b:a <bitrate> -c:a libopus -vbr on -af "volume=replaygain=track:replaygain_preamp=6dB:replaygain_noclip=0, alimiter=level=disabled, asidedata=mode=delete:type=REPLAYGAIN" -metadata replaygain_album_gain= -metadata replaygain_album_peak= -metadata replaygain_track_gain= -metadata replaygain_track_peak= -metadata r128_album_gain= -metadata r128_track_gain= -f opus -`)
 
-	PCM16le = NewProfile("audio/wav", 0, `ffmpeg -v 0 -i <file> -ss <seek> -c:a pcm_s16le -ac 2 -f s16le -`)
+	PCM16le = NewProfile("audio/wav", "wav", 0, `ffmpeg -v 0 -i <file> -ss <seek> -c:a pcm_s16le -ac 2 -f s16le -`)
 )
 
 type BitRate int // kb/s
@@ -61,15 +61,17 @@ type Profile struct {
 	bitrate BitRate // the default bitrate, but the user can request a different one
 	seek    time.Duration
 	mime    string
+	suffix	string
 	exec    string
 }
 
 func (p *Profile) BitRate() BitRate    { return p.bitrate }
 func (p *Profile) Seek() time.Duration { return p.seek }
+func (p *Profile) Suffix() string      { return p.suffix }
 func (p *Profile) MIME() string        { return p.mime }
 
-func NewProfile(mime string, bitrate BitRate, exec string) Profile {
-	return Profile{mime: mime, bitrate: bitrate, exec: exec}
+func NewProfile(mime string, suffix string, bitrate BitRate, exec string) Profile {
+	return Profile{mime: mime, suffix: suffix, bitrate: bitrate, exec: exec}
 }
 
 func WithBitrate(p Profile, bitRate BitRate) Profile {


### PR DESCRIPTION
This fixes a problem stated in the second comment of #106
The problem was that gonic didn't send the TranscodedContentType and TranscodedSuffix attributes when building the album list, playlist, etc... So the clients like DSub used the "suffix" xml attribute as the file suffix even if the file was being transcoded to another format.

Sorry if the code is somewhat "dirty". I don't know the project very well and it's my first time trying to fix something in go.
Feel free to fix any mistakes or re-implement it if you deem it necessary.

The fix builds and works with folder-browsing, tag-browsing and with and without a transcode profile.