### PR TITLE
delete the mpv tmp file after creation

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -363,6 +363,9 @@ func (s *Server) StartJukebox(mpvExtraArgs []string) (FuncExecute, FuncInterrupt
 			if err != nil {
 				return fmt.Errorf("create tmp sock file: %w", err)
 			}
+			if err := os.Remove(sockFile.Name()); err != nil {
+				return fmt.Errorf("delete tmp sock file: %w", err)
+			}
 			if err := s.jukebox.Start(sockFile.Name(), mpvExtraArgs); err != nil {
 				return fmt.Errorf("start jukebox: %w", err)
 			}


### PR DESCRIPTION
Previously, a temporary path was not only being generated but also touched, therefore the os.Stat check to verify mpv had started was really doing nothing and just succeeding at the first attempt.

Closes #265

In order to test on your machine (a Pi is not needed I believe) you can just add an `mpv` sh script to your `$PATH` (before the actual `mpv`) with just a `sleep 10` inside. This will simulate a somewhat slow process starting (what I guess happens on a Pi). Without this change, the error would have been `failed to connect` as the startup check would always return a false positive. Now it properly hangs for 5s and errors out with `mpv never started`.

If you have the chance @marlop352, give this patch a try on your Pi. I don't currently have one on hand.