### PR TITLE
feat(scrobble): only send musicbrainz id if it's a valid uuid

### DIFF
--- a/scrobble/lastfm/lastfm.go
+++ b/scrobble/lastfm/lastfm.go
@@ -14,6 +14,7 @@ import (
 	"strconv"
 	"time"
 
+	"github.com/google/uuid"
 	"go.senan.xyz/gonic/db"
 	"go.senan.xyz/gonic/scrobble"
 )
@@ -260,10 +261,15 @@ func (s *Scrobbler) Scrobble(user *db.User, track *db.Track, stamp time.Time, su
 	params.Add("track", track.TagTitle)
 	params.Add("trackNumber", strconv.Itoa(track.TagTrackNumber))
 	params.Add("album", track.Album.TagTitle)
-	params.Add("mbid", track.TagBrainzID)
 	params.Add("albumArtist", track.Artist.Name)
 	params.Add("duration", strconv.Itoa(track.Length))
 	params.Add("api_sig", getParamSignature(params, secret))
+
+	// make sure we provide a valid uuid, since some users may have an incorrect mbid in their tags
+	if _, err := uuid.Parse(track.TagBrainzID); err == nil {
+		params.Add("mbid", track.TagBrainzID)
+	}
+
 	_, err = makeRequest("POST", params)
 	return err
 }

--- a/scrobble/listenbrainz/listenbrainz.go
+++ b/scrobble/listenbrainz/listenbrainz.go
@@ -10,6 +10,7 @@ import (
 	"net/http/httputil"
 	"time"
 
+	"github.com/google/uuid"
 	"go.senan.xyz/gonic/db"
 	"go.senan.xyz/gonic/scrobble"
 )
@@ -57,11 +58,18 @@ func (s *Scrobbler) Scrobble(user *db.User, track *db.Track, stamp time.Time, su
 	if user.ListenBrainzURL == "" || user.ListenBrainzToken == "" {
 		return nil
 	}
+
+	// make sure we provide a valid uuid, since some users may have an incorrect mbid in their tags
+	var trackMBID string
+	if _, err := uuid.Parse(track.TagBrainzID); err == nil {
+		trackMBID = track.TagBrainzID
+	}
+
 	payload := &Payload{
 		TrackMetadata: &TrackMetadata{
 			AdditionalInfo: &AdditionalInfo{
 				TrackNumber:   track.TagTrackNumber,
-				RecordingMBID: track.TagBrainzID,
+				RecordingMBID: trackMBID,
 				TrackLength:   track.Length,
 			},
 			ArtistName:  track.TagTrackArtist,


### PR DESCRIPTION
since some people may have a non musicbrainz uuid in the tag's place. eg with the discogs/lastfm plugins for beets.io
