### PR TITLE
Add "audiophile" transcode profile

### DIFF
--- a/transcode/transcode.go
+++ b/transcode/transcode.go
@@ -27,6 +27,7 @@ var UserProfiles = map[string]Profile{
 	"opus_128_car": Opus128RGLoud,
 	"opus_128":     Opus128,
 	"opus_128_rg":  Opus128RG,
+	"opus_192":     Opus192,
 }
 
 // Store as simple strings, since we may let the user provide their own profiles soon
@@ -41,6 +42,8 @@ var (
 	Opus128       = NewProfile("audio/ogg", "opus", 128, `ffmpeg -v 0 -i <file> -ss <seek> -map 0:a:0 -vn -b:a <bitrate> -c:a libopus -vbr on -f opus -`)
 	Opus128RG     = NewProfile("audio/ogg", "opus", 128, `ffmpeg -v 0 -i <file> -ss <seek> -map 0:a:0 -vn -b:a <bitrate> -c:a libopus -vbr on -af "volume=replaygain=track:replaygain_preamp=6dB:replaygain_noclip=0, alimiter=level=disabled, asidedata=mode=delete:type=REPLAYGAIN" -metadata replaygain_album_gain= -metadata replaygain_album_peak= -metadata replaygain_track_gain= -metadata replaygain_track_peak= -metadata r128_album_gain= -metadata r128_track_gain= -f opus -`)
 	Opus128RGLoud = NewProfile("audio/ogg", "opus", 128, `ffmpeg -v 0 -i <file> -ss <seek> -map 0:a:0 -vn -b:a <bitrate> -c:a libopus -vbr on -af "aresample=96000:resampler=soxr, volume=replaygain=track:replaygain_preamp=15dB:replaygain_noclip=0, alimiter=level=disabled, asidedata=mode=delete:type=REPLAYGAIN" -metadata replaygain_album_gain= -metadata replaygain_album_peak= -metadata replaygain_track_gain= -metadata replaygain_track_peak= -metadata r128_album_gain= -metadata r128_track_gain= -f opus -`)
+
+	Opus192       = NewProfile("audio/ogg", "opus", 192, `ffmpeg -v 0 -i <file> -ss <seek> -map 0:a:0 -vn -b:a <bitrate> -c:a libopus -vbr on -f opus -`)
 )
 
 type BitRate uint // kilobits/s


### PR DESCRIPTION
This diff adds the 192kbps OPUS transcoding profile named opus_audiophile. While 128kbps is already near transparent and good for most use cases, sometimes (or by some people) a bit more is preferred. These are typically for dedicated high quality wireless audio link (A2DP-bluetooth) enabled headphones and Hi-Fi adapters.

The 160-192kbps range is considered to be transparent with very low chance of artifacts (only with very few and specific samples)[1][2].

[1] https://wiki.hydrogenaud.io/index.php?title=Opus
[2] https://ceur-ws.org/Vol-2654/paper25.pdf