### PR TITLE
Fix watcher panic

### DIFF
--- a/scanner/scanner.go
+++ b/scanner/scanner.go
@@ -186,7 +186,10 @@ func (s *Scanner) ExecuteWatch() error {
 				t.Reset(10 * time.Second)
 			}
 			fileInfo, err := os.Stat(event.Name)
-			if err != nil && fileInfo.IsDir() {
+			if err != nil {
+				break
+			}
+			if fileInfo.IsDir() {
 				dirName = event.Name
 			} else {
 				dirName = filepath.Dir(event.Name)


### PR DESCRIPTION
Fixes: https://github.com/sentriz/gonic/issues/287

```golang
fileInfo, err := os.Stat(event.Name)
if err != nil && fileInfo.IsDir()
```

This statement is meaningless because if error is not empty then fileInfo be always empty. It causes panic which is mentioned in the issue.

My solution is just skip cycle if file moved or deleted during the scan.