### PR TITLE
search logic alter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,5 @@ gonicembed
 *.swp
 .tags*
 *.test
+.envrc
+vendor/

--- a/server/ctrlsubsonic/handlers_by_tags.go
+++ b/server/ctrlsubsonic/handlers_by_tags.go
@@ -209,8 +209,11 @@ func toLikeStrm(vs []string, col string) (string, []sql.NamedArg) {
 	qparts := []string{}
 	qparams := []sql.NamedArg{}
 	for idx, v := range vs {
-		qparts = append(qparts, fmt.Sprintf("%s LIKE @%s_%d OR %s_u_dec LIKE @%s_%d", col, col, idx, col, col, idx))
-		qparams = append(qparams, sql.Named(fmt.Sprintf("%s_%d", col, idx), fmt.Sprintf("%%%s%%", strings.Trim(v, `*"' `))))
+		param := strings.Trim(v, `*"' `)
+		if len(param) > 0 {
+			qparts = append(qparts, fmt.Sprintf("%s LIKE @%s_%d OR %s_u_dec LIKE @%s_%d", col, col, idx, col, col, idx))
+			qparams = append(qparams, sql.Named(fmt.Sprintf("%s_%d", col, idx), fmt.Sprintf("%%%s%%", param)))
+		}
 	}
 	return strings.Join(qparts, " OR "), qparams
 }

--- a/server/ctrlsubsonic/handlers_by_tags.go
+++ b/server/ctrlsubsonic/handlers_by_tags.go
@@ -248,11 +248,11 @@ func (c *Controller) ServeSearchThree(r *http.Request) *spec.Response {
 	if err != nil {
 		return spec.NewError(10, "please provide a `query` parameter")
 	}
-	query_parts := append(strings.Split(strings.Trim(query, " "), " "), []string{}...)
+	queryParts := append(strings.Split(strings.Trim(query, " "), " "), []string{}...)
 	results := &spec.SearchResultThree{}
 
 	// search artists
-	qsql, qparams := toLikeStrm(query_parts, "name")
+	qsql, qparams := toLikeStrm(queryParts, "name")
 	var artists []*db.Artist
 	q := c.DB.
 		Select("*, count(albums.id) album_count").
@@ -276,17 +276,17 @@ func (c *Controller) ServeSearchThree(r *http.Request) *spec.Response {
 	}
 
 	// search albums
-	qal_sql, qalparams := toLikeStrm(query_parts, "tag_title")
+	qalSql, qalParams := toLikeStrm(query_parts, "tag_title")
 	var albums []*db.Album
 	q = c.DB.
 		Preload("TagArtist").
 		Preload("Genres").
 		Preload("AlbumStar", "user_id=?", user.ID).
 		Preload("AlbumRating", "user_id=?", user.ID).
-		Where(qal_sql, qalparams)
-	if artist_ids := toArtistIds(results); len(artist_ids) > 0 {
-		qsql, qparams := toOrIds(artist_ids, "tag_artist_id")
-		q = q.Where(qsql, qparams)
+		Where(qalSql, qalParams)
+	if artistIds := toArtistIds(results); len(artistIds) > 0 {
+		qSql, qParams := toOrIds(artistIds, "tag_artist_id")
+		q = q.Where(qSql, qParams)
 	}
 	if m := getMusicFolder(c.MusicPaths, params); m != "" {
 		q = q.Where("root_dir=?", m)
@@ -311,13 +311,13 @@ func (c *Controller) ServeSearchThree(r *http.Request) *spec.Response {
 		Preload("TrackStar", "user_id=?", user.ID).
 		Preload("TrackRating", "user_id=?", user.ID).
 		Where(qtr_sql, qtrparams)
-	if album_ids := toAlbumIds(results); album_ids != nil {
-		qsql_al, qparams_al := toOrIds(album_ids, "album_id")
-		q = q.Where(qsql_al, qparams_al)
+	if albumIds := toAlbumIds(results); albumIds != nil {
+		qSqlAl, qParamsAl := toOrIds(albumIds, "album_id")
+		q = q.Where(qSqlAl, qParamsAl)
 	}
-	if artist_ids := toArtistIds(results); artist_ids != nil {
-		qsql_ar, qparams_ar := toOrIds(artist_ids, "artist_id")
-		q = q.Where(qsql_ar, qparams_ar)
+	if artistIds := toArtistIds(results); artistIds != nil {
+		qSqlAr, qParamsAr := toOrIds(artistIds, "artist_id")
+		q = q.Where(qSqlAr, qParamsAr)
 	}
 	if m := getMusicFolder(c.MusicPaths, params); m != "" {
 		q = q.

--- a/server/ctrlsubsonic/handlers_by_tags.go
+++ b/server/ctrlsubsonic/handlers_by_tags.go
@@ -252,12 +252,12 @@ func (c *Controller) ServeSearchThree(r *http.Request) *spec.Response {
 	results := &spec.SearchResultThree{}
 
 	// search artists
-	qsql, qparams := toLikeStrm(queryParts, "name")
+	qSql, qParams := toLikeStrm(queryParts, "name")
 	var artists []*db.Artist
 	q := c.DB.
 		Select("*, count(albums.id) album_count").
 		Group("artists.id").
-		Where(qsql, qparams).
+		Where(qSql, qParams).
 		Joins("JOIN albums ON albums.tag_artist_id=artists.id").
 		Preload("ArtistStar", "user_id=?", user.ID).
 		Preload("ArtistRating", "user_id=?", user.ID).
@@ -276,7 +276,7 @@ func (c *Controller) ServeSearchThree(r *http.Request) *spec.Response {
 	}
 
 	// search albums
-	qalSql, qalParams := toLikeStrm(query_parts, "tag_title")
+	qalSql, qalParams := toLikeStrm(queryParts, "tag_title")
 	var albums []*db.Album
 	q = c.DB.
 		Preload("TagArtist").
@@ -303,14 +303,14 @@ func (c *Controller) ServeSearchThree(r *http.Request) *spec.Response {
 
 	// search tracks
 	var tracks []*db.Track
-	qtr_sql, qtrparams := toLikeStrm(query_parts, "tag_title")
+	qtrSql, qtrParams := toLikeStrm(queryParts, "tag_title")
 	q = c.DB.
 		Preload("Album").
 		Preload("Album.TagArtist").
 		Preload("Genres").
 		Preload("TrackStar", "user_id=?", user.ID).
 		Preload("TrackRating", "user_id=?", user.ID).
-		Where(qtr_sql, qtrparams)
+		Where(qtrSql, qtrParams)
 	if albumIds := toAlbumIds(results); albumIds != nil {
 		qSqlAl, qParamsAl := toOrIds(albumIds, "album_id")
 		q = q.Where(qSqlAl, qParamsAl)

--- a/server/ctrlsubsonic/handlers_by_tags.go
+++ b/server/ctrlsubsonic/handlers_by_tags.go
@@ -252,12 +252,12 @@ func (c *Controller) ServeSearchThree(r *http.Request) *spec.Response {
 	results := &spec.SearchResultThree{}
 
 	// search artists
-	qSql, qParams := toLikeStrm(queryParts, "name")
+	qSQL, qParams := toLikeStrm(queryParts, "name")
 	var artists []*db.Artist
 	q := c.DB.
 		Select("*, count(albums.id) album_count").
 		Group("artists.id").
-		Where(qSql, qParams).
+		Where(qSQL, qParams).
 		Joins("JOIN albums ON albums.tag_artist_id=artists.id").
 		Preload("ArtistStar", "user_id=?", user.ID).
 		Preload("ArtistRating", "user_id=?", user.ID).
@@ -276,17 +276,17 @@ func (c *Controller) ServeSearchThree(r *http.Request) *spec.Response {
 	}
 
 	// search albums
-	qalSql, qalParams := toLikeStrm(queryParts, "tag_title")
+	qalSQL, qalParams := toLikeStrm(queryParts, "tag_title")
 	var albums []*db.Album
 	q = c.DB.
 		Preload("TagArtist").
 		Preload("Genres").
 		Preload("AlbumStar", "user_id=?", user.ID).
 		Preload("AlbumRating", "user_id=?", user.ID).
-		Where(qalSql, qalParams)
+		Where(qalSQL, qalParams)
 	if artistIds := toArtistIds(results); len(artistIds) > 0 {
-		qSql, qParams := toOrIds(artistIds, "tag_artist_id")
-		q = q.Where(qSql, qParams)
+		qSQL, qParams := toOrIds(artistIds, "tag_artist_id")
+		q = q.Where(qSQL, qParams)
 	}
 	if m := getMusicFolder(c.MusicPaths, params); m != "" {
 		q = q.Where("root_dir=?", m)
@@ -303,21 +303,21 @@ func (c *Controller) ServeSearchThree(r *http.Request) *spec.Response {
 
 	// search tracks
 	var tracks []*db.Track
-	qtrSql, qtrParams := toLikeStrm(queryParts, "tag_title")
+	qtrSQL, qtrParams := toLikeStrm(queryParts, "tag_title")
 	q = c.DB.
 		Preload("Album").
 		Preload("Album.TagArtist").
 		Preload("Genres").
 		Preload("TrackStar", "user_id=?", user.ID).
 		Preload("TrackRating", "user_id=?", user.ID).
-		Where(qtrSql, qtrParams)
+		Where(qtrSQL, qtrParams)
 	if albumIds := toAlbumIds(results); albumIds != nil {
-		qSqlAl, qParamsAl := toOrIds(albumIds, "album_id")
-		q = q.Where(qSqlAl, qParamsAl)
+		qSQLAl, qParamsAl := toOrIds(albumIds, "album_id")
+		q = q.Where(qSQLAl, qParamsAl)
 	}
 	if artistIds := toArtistIds(results); artistIds != nil {
-		qSqlAr, qParamsAr := toOrIds(artistIds, "artist_id")
-		q = q.Where(qSqlAr, qParamsAr)
+		qSQLAr, qParamsAr := toOrIds(artistIds, "artist_id")
+		q = q.Where(qSQLAr, qParamsAr)
 	}
 	if m := getMusicFolder(c.MusicPaths, params); m != "" {
 		q = q.


### PR DESCRIPTION
change how the search work, currently it just gets the query and use it like it, this PR

* splits the query to words, searches for artist LIKE each word 
* same applied to albums, but includes any found artists in the filter
* same for track but includes if anything is found from above

let's presume you haev all dream theater albums. searching right now for "dream theater space" will return you nothing, after the PR it will return the artist and two songs, lifhting shadow of a dream, space dye vest