### PR TITLE
Fixes #306, load playlists from server-local directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ password can then be changed from the web interface
 | `GONIC_PODCAST_PATH`           | `-podcast-path`           | path to a podcasts directory                                                                                |
 | `GONIC_CACHE_PATH`             | `-cache-path`             | path to store audio transcodes, covers, etc                                                                 |
 | `GONIC_DB_PATH`                | `-db-path`                | **optional** path to database file                                                                          |
+| `GONIC_PLAYLIST_PATH`          | `-playlist-path`          | **optional** path to a directory containing `.m3u` playlists                                                |
 | `GONIC_HTTP_LOG`               | `-http-log`               | **optional** http request logging, enabled by default                                                       |
 | `GONIC_LISTEN_ADDR`            | `-listen-addr`            | **optional** host and port to listen on (eg. `0.0.0.0:4747`, `127.0.0.1:4747`) (_default_ `0.0.0.0:4747`)   |
 | `GONIC_TLS_CERT`               | `-tls-cert`               | **optional** path to a TLS cert (enables HTTPS listening)                                                   |

--- a/cmd/gonic/gonic.go
+++ b/cmd/gonic/gonic.go
@@ -39,6 +39,7 @@ func main() {
 	confPodcastPath := set.String("podcast-path", "", "path to podcasts")
 	confCachePath := set.String("cache-path", "", "path to cache")
 	confDBPath := set.String("db-path", "gonic.db", "path to database (optional)")
+	confPlaylistPath := set.String("playlist-path", "", "path to directory containing m3u playlist files")
 	confScanIntervalMins := set.Int("scan-interval", 0, "interval (in minutes) to automatically scan music (optional)")
 	confScanAtStart := set.Bool("scan-at-start-enabled", false, "whether to perform an initial scan at startup (optional)")
 	confScanWatcher := set.Bool("scan-watcher-enabled", false, "whether to watch file system for new music and rescan (optional)")
@@ -127,6 +128,7 @@ func main() {
 		ProxyPrefix:    *confProxyPrefix,
 		GenreSplit:     *confGenreSplit,
 		PodcastPath:    filepath.Clean(*confPodcastPath),
+		PlaylistPath:   *confPlaylistPath,
 		HTTPLog:        *confHTTPLog,
 		JukeboxEnabled: *confJukeboxEnabled,
 	})

--- a/contrib/config
+++ b/contrib/config
@@ -33,6 +33,10 @@ music-path                  <path to your music dir>
 # podcast-path                /var/cache/podcast
 podcast-path                <path to your podcasts dir>
 
+# Path to playlist files. Optional, and must be specified only once.
+# playlist-path              /srv/audio/playlists
+playlist-path                <path to your playlists dir>
+
 # Age (in days) to purge podcast episodes if not accessed. Disabled by default.
 #podcast-purge-age           0
 

--- a/mockfs/mockfs.go
+++ b/mockfs/mockfs.go
@@ -59,7 +59,7 @@ func new(t testing.TB, dirs []string) *MockFS {
 	}
 
 	tagReader := &tagReader{paths: map[string]*tagReaderResult{}}
-	scanner := scanner.New(absDirs, dbc, ";", tagReader)
+	scanner := scanner.New(absDirs, "", dbc, ";", tagReader)
 
 	return &MockFS{
 		t:         t,

--- a/scanner/scanner.go
+++ b/scanner/scanner.go
@@ -112,8 +112,7 @@ func (s *Scanner) ScanAndClean(opts ScanOptions) (*Context, error) {
 		return nil, fmt.Errorf("clean genres: %w", err)
 	}
 
-	var playlistWalker func(string, fs.DirEntry, error) error
-	playlistWalker = func(absPath string, d fs.DirEntry, err error) error {
+	playlistWalker := func(absPath string, d fs.DirEntry, err error) error {
 		if d.IsDir() {
 			return nil
 		}
@@ -297,7 +296,10 @@ func (s *Scanner) loadPlaylistCallback(c *Context, dir string, absPath string, d
 	// TODO admin is always user ID 1, but hard-coding it here is smelly
 	errs, success := PlaylistParse(s.db, 1, d.Name(), file)
 	if !success {
-		return fmt.Errorf(strings.Join(errs, "\n"))
+		for _, err := range errs {
+			log.Printf(err)
+		}
+		return fmt.Errorf("errors encountered during parsing playlists; check the logs")
 	}
 	return nil
 }

--- a/server/ctrlsubsonic/ctrl.go
+++ b/server/ctrlsubsonic/ctrl.go
@@ -33,6 +33,7 @@ type Controller struct {
 	CoverCachePath string
 	PodcastsPath   string
 	MusicPaths     paths.MusicPaths
+	PlaylistPath   string
 	Jukebox        *jukebox.Jukebox
 	Scrobblers     []scrobble.Scrobbler
 	Podcasts       *podcasts.Podcasts

--- a/server/server.go
+++ b/server/server.go
@@ -35,6 +35,7 @@ type Options struct {
 	PodcastPath    string
 	CachePath      string
 	CoverCachePath string
+	PlaylistPath   string
 	ProxyPrefix    string
 	GenreSplit     string
 	HTTPLog        bool
@@ -52,7 +53,7 @@ type Server struct {
 func New(opts Options) (*Server, error) {
 	tagger := &tags.TagReader{}
 
-	scanner := scanner.New(opts.MusicPaths.Paths(), opts.DB, opts.GenreSplit, tagger)
+	scanner := scanner.New(opts.MusicPaths.Paths(), opts.PlaylistPath, opts.DB, opts.GenreSplit, tagger)
 	base := &ctrlbase.Controller{
 		DB:          opts.DB,
 		ProxyPrefix: opts.ProxyPrefix,
@@ -98,6 +99,7 @@ func New(opts Options) (*Server, error) {
 		CoverCachePath: opts.CoverCachePath,
 		PodcastsPath:   opts.PodcastPath,
 		MusicPaths:     opts.MusicPaths,
+		PlaylistPath:   opts.PlaylistPath,
 		Scrobblers:     []scrobble.Scrobbler{&lastfm.Scrobbler{DB: opts.DB}, &listenbrainz.Scrobbler{}},
 		Podcasts:       podcast,
 		Transcoder:     cacheTranscoder,


### PR DESCRIPTION
This is a naïve implementation of loading playlists from a directory on the server. It adds a configuration option for telling the server where the directory of playlists is, and it will (recursively) load any `.m3u` and `.m3u8` files it finds there. The playlists are added under the default admin user, and are set public.

Playlists are loaded into the DB as if they'd been uploaded by the user through the UI. The code for doing so was reused; the biggest change was relocating the code that does that from the `ctrladmin` package to the `scanner` package.

As discussed in #306, this may not be the way gonic wants to handle playlists going forward; however, that sort of change would (a) require more discussion and/or design, and (b) be a lot bigger. I believe that this PR would neither impede nor make such a more radical design change more difficult to implement, and as it addresses the request I'm submitting it even though it may not be the ideal, ultimate design.