### PR TITLE
Bugfix: Add playlists directory to volumes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -31,7 +31,7 @@ COPY --from=builder \
 COPY --from=builder \
     /src/gonic \
     /bin/
-VOLUME ["/cache", "/data", "/music", "/podcasts"]
+VOLUME ["/cache", "/data", "/music", "/playlists", "/podcasts"]
 EXPOSE 80
 ENV TZ ""
 ENV GONIC_DB_PATH /data/gonic.db

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -27,7 +27,7 @@ COPY --from=builder \
 COPY --from=builder \
     /src/gonic \
     /bin/
-VOLUME ["/cache", "/data", "/music", "/podcasts"]
+VOLUME ["/cache", "/data", "/music", "/playlists", "/podcasts"]
 EXPOSE 80
 ENV GONIC_DB_PATH /data/gonic.db
 ENV GONIC_LISTEN_ADDR :80


### PR DESCRIPTION
What?
=====
Add the `/playlists` directory to the list of volumes, so the server doesn't exit when validating the playlist path on startup.

Why?
=====
With the current behavior, the server process exits when no playlist directory is found, see: https://github.com/sentriz/gonic/blob/7dc9575e52538cf4fd39715193b5c760e1cc477b/cmd/gonic/gonic.go#L104