### PR TITLE
Revert | Add playlists directory to docker volumes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -31,7 +31,7 @@ COPY --from=builder \
 COPY --from=builder \
     /src/gonic \
     /bin/
-VOLUME ["/cache", "/data", "/music", "/playlists", "/podcasts"]
+VOLUME ["/cache", "/data", "/music", "/podcasts"]
 EXPOSE 80
 ENV TZ ""
 ENV GONIC_DB_PATH /data/gonic.db

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -27,7 +27,7 @@ COPY --from=builder \
 COPY --from=builder \
     /src/gonic \
     /bin/
-VOLUME ["/cache", "/data", "/music", "/playlists", "/podcasts"]
+VOLUME ["/cache", "/data", "/music", "/podcasts"]
 EXPOSE 80
 ENV GONIC_DB_PATH /data/gonic.db
 ENV GONIC_LISTEN_ADDR :80


### PR DESCRIPTION
This PR reverts commit aae06836715f4159ac5cacf83ae5c2d5e3e4f52f as the original change (see PR #314) might cause data loss for existing users if the `playlists` volume is not explicitly mapped to permanent storage.