### PR TITLE
Update handlers_internet_radio.go

### DIFF
--- a/server/ctrlsubsonic/handlers_internet_radio.go
+++ b/server/ctrlsubsonic/handlers_internet_radio.go
@@ -44,7 +44,7 @@ func (c *Controller) ServeCreateInternetRadioStation(r *http.Request) *spec.Resp
 		return spec.NewError(10, "no name provided: %v", err)
 	}
 	homepageURL, err := params.Get("homepageUrl")
-	if err == nil {
+	if err == nil && homepageURL != "" {
 		if _, err := url.ParseRequestURI(homepageURL); err != nil {
 			return spec.NewError(70, "bad homepage URL provided: %v", err)
 		}


### PR DESCRIPTION
By the https://opensubsonic.netlify.app/docs/endpoints/createinternetradiostation/ the `homepageURL` is not requirement option