### PR TITLE
[WIP] LDAP Authentication

### DIFF
--- a/server/ctrladmin/adminui/pages/home.tmpl
+++ b/server/ctrladmin/adminui/pages/home.tmpl
@@ -35,7 +35,9 @@
         {{ end }}
     {{ end }}
     {{ if .User.IsAdmin }}
-        <div class="col-span-full">{{ component "link" (props . "To" (path "/admin/create_user")) }}create new{{ end }}</div>
+				<div class="col-span-full">{{ component "link" (props . "To" (path 
+				"/admin/create_user")) }}create new{{ end }} {{component "link" 
+				(props . "To" (path "/admin/ldap")) }}LDAP{{ end }}</div>
     {{ end }}
 </div>
 {{ end }}

--- a/server/ctrladmin/adminui/pages/ldap.tmpl
+++ b/server/ctrladmin/adminui/pages/ldap.tmpl
@@ -35,13 +35,16 @@
 					value="389"
 				>
 
-				
-
-				<label>
+				<label >
 					<input
 						type="checkbox"
 						id="tls"
 						name="tls"
+						value="TLS"
+						style="
+						all: revert !important;
+						width: 20px !important;
+						height: 20px !important;"
 					>
 					TLS
 				</label>

--- a/server/ctrladmin/adminui/pages/ldap.tmpl
+++ b/server/ctrladmin/adminui/pages/ldap.tmpl
@@ -1,0 +1,69 @@
+{{ component "layout" . }}
+{{ component "layout_user" . }}
+
+{{ component "block" (props .
+    "Icon" "user"
+		"Name" "configuring LDAP"
+) }}
+		<form class="flex flex-col gap-2 items-end" action="{{ path 
+		"/admin/ldap_do" }}" method="post">
+				<input
+					type="username"
+					id="bind_user_uid"
+					name="bind_user"
+					placeholder="bind username"
+				>
+				<input
+					type="password"
+					id="bind_user_password"
+					name="bind_user_password"
+					placeholder="bind password"
+				>
+				
+				<input
+					type="text"
+					id="fqdn"
+					name="fqdn"
+					placeholder="LDAP server"
+				>
+				
+				<input
+					type="number"
+					id="port"
+					name="port"
+					placeholder="port"
+					value="389"
+				>
+
+				
+
+				<label>
+					<input
+						type="checkbox"
+						id="tls"
+						name="tls"
+					>
+					TLS
+				</label>
+
+				<input
+					type="text"
+					id="base_cn"
+					name="base_cn"
+					placeholder="Base CN"
+				>
+				
+				<input
+					type="text"
+					id="filter"
+					name="filter"
+					placeholder="filter"
+				>
+				
+
+				<input type="submit" value="update">
+    </form>
+{{ end }}
+
+{{ end }}
+{{ end }}

--- a/server/ctrladmin/adminui/pages/ldap.tmpl
+++ b/server/ctrladmin/adminui/pages/ldap.tmpl
@@ -9,7 +9,7 @@
 		"/admin/ldap_do" }}" method="post">
 				<input
 					type="username"
-					id="bind_user_uid"
+					id="bind_user"
 					name="bind_user"
 					placeholder="bind username"
 				>
@@ -51,9 +51,9 @@
 
 				<input
 					type="text"
-					id="base_cn"
-					name="base_cn"
-					placeholder="Base CN"
+					id="base_dn"
+					name="base_dn"
+					placeholder="Base DN"
 				>
 				
 				<input

--- a/server/ctrladmin/handlers.go
+++ b/server/ctrladmin/handlers.go
@@ -168,7 +168,7 @@ func (c *Controller) ServeLDAPConfig(r *http.Request) *Response {
 
 func (c *Controller) ServeLDAPConfigDo(r *http.Request) *Response {
 	bindUID := r.FormValue("bind_user")
-	bindPSWD := r.FormValue("bind_user_password")
+	bindPSWD := r.FormValue("bind_user_password") // TODO: Secure this better.
 	fqdn := r.FormValue("fqdn")
 	port := r.FormValue("port")
 	tls := r.FormValue("tls")

--- a/server/ctrladmin/handlers.go
+++ b/server/ctrladmin/handlers.go
@@ -157,6 +157,15 @@ func (c *Controller) ServeUnlinkListenBrainzDo(r *http.Request) *Response {
 	return &Response{redirect: "/admin/home"}
 }
 
+func (c *Controller) ServeLDAPConfig(r *http.Request) *Response {
+	data := &templateData{}
+
+	return &Response{
+		template: "ldap.tmpl",
+		data: data,
+	}
+}
+
 func (c *Controller) ServeChangeUsername(r *http.Request) *Response {
 	user, err := selectedUserIfAdmin(c, r)
 	if err != nil {

--- a/server/ctrladmin/handlers.go
+++ b/server/ctrladmin/handlers.go
@@ -166,6 +166,34 @@ func (c *Controller) ServeLDAPConfig(r *http.Request) *Response {
 	}
 }
 
+func (c *Controller) ServeLDAPConfigDo(r *http.Request) *Response {
+	bindUID := r.FormValue("bind_user")
+	bindPSWD := r.FormValue("bind_user_password")
+	fqdn := r.FormValue("fqdn")
+	port := r.FormValue("port")
+	tls := r.FormValue("tls")
+	baseDN := r.FormValue("base_dn")
+	filter := r.FormValue("filter")
+	
+	if bindUID == "" || bindPSWD == "" || fqdn == "" || port == "" || port == "" || baseDN == "" || filter == "" {
+		return &Response{
+			redirect: r.Referer(),
+			flashW:   []string{"please provide a bind username and password, a FQDN, port, base CN, and filter"},
+		}
+	}
+	
+	c.DB.SetSetting("ldap_bind_user", bindUID)
+	c.DB.SetSetting("ldap_bind_user_password", bindPSWD)
+	
+	c.DB.SetSetting("ldap_fqdn", fqdn)
+	c.DB.SetSetting("ldap_port", port)
+	c.DB.SetSetting("ldap_tls", tls)
+	c.DB.SetSetting("ldap_base_dn", baseDN)
+	c.DB.SetSetting("ldap_filter", filter)
+
+	return &Response{redirect: "/admin/home"}
+}
+
 func (c *Controller) ServeChangeUsername(r *http.Request) *Response {
 	user, err := selectedUserIfAdmin(c, r)
 	if err != nil {

--- a/server/server.go
+++ b/server/server.go
@@ -173,6 +173,7 @@ func setupAdmin(r *mux.Router, ctrl *ctrladmin.Controller) {
 	routUser.Use(ctrl.WithUserSession)
 	routUser.Handle("/logout", ctrl.HR(ctrl.ServeLogout)) // "raw" handler, updates session
 	routUser.Handle("/home", ctrl.H(ctrl.ServeHome))
+	routUser.Handle("/ldap", ctrl.H(ctrl.ServeLDAPConfig))
 	routUser.Handle("/change_username", ctrl.H(ctrl.ServeChangeUsername))
 	routUser.Handle("/change_username_do", ctrl.H(ctrl.ServeChangeUsernameDo))
 	routUser.Handle("/change_password", ctrl.H(ctrl.ServeChangePassword))

--- a/server/server.go
+++ b/server/server.go
@@ -174,6 +174,7 @@ func setupAdmin(r *mux.Router, ctrl *ctrladmin.Controller) {
 	routUser.Handle("/logout", ctrl.HR(ctrl.ServeLogout)) // "raw" handler, updates session
 	routUser.Handle("/home", ctrl.H(ctrl.ServeHome))
 	routUser.Handle("/ldap", ctrl.H(ctrl.ServeLDAPConfig))
+	routUser.Handle("/ldap_do", ctrl.H(ctrl.ServeLDAPConfigDo))
 	routUser.Handle("/change_username", ctrl.H(ctrl.ServeChangeUsername))
 	routUser.Handle("/change_username_do", ctrl.H(ctrl.ServeChangeUsernameDo))
 	routUser.Handle("/change_password", ctrl.H(ctrl.ServeChangePassword))


### PR DESCRIPTION
## To-do

- [ ] LDAP configuration page.
  - ~~Configuration on the admin page~~ (`/ldap`)
  - ~~Saving the configuration to the database~~ (`/ldap_do`)
  - Reading the current configuration and setting the values on `/ldap`
- [ ] Connect to the LDAP server.
- [ ] Log in using an LDAP account.
  - Check the user's credentials against the LDAP server.
  - Automatically create a user account if there is a specific LDAP group (ie. `media`).

## Limitations

- Currently the bind user's password is stored unencrypted, this seems to be a limitation of [`go-ldap`](https://github.com/go-ldap/ldap).
- There may be users who the LDAP server believes should be an administrator (ie. of group `media_admin`), currently this implementation has no filter for detecting an admin user. 

---

Fixes: #44.