### PR TITLE
Parse podcast description from HTML to text just as with episodes.

### DIFF
--- a/server/ctrlsubsonic/spec/construct_podcast.go
+++ b/server/ctrlsubsonic/spec/construct_podcast.go
@@ -6,11 +6,15 @@ import (
 )
 
 func NewPodcastChannel(p *db.Podcast) *PodcastChannel {
+	desc, err := html2text.FromString(p.Description, html2text.Options{TextOnly: true})
+	if (err != nil) {
+		desc = ""
+	}
 	ret := &PodcastChannel{
 		ID:               p.SID(),
 		OriginalImageURL: p.ImageURL,
 		Title:            p.Title,
-		Description:      p.Description,
+		Description:      desc,
 		URL:              p.URL,
 		CoverArt:         p.SID(),
 		Status:           "skipped",


### PR DESCRIPTION
If you're not going to take the change to make this a config option, then you should take this PR instead to parse podcast descriptions just as with podcast episodes, which is in that PR and is a good idea regardless IMO.