### PR TITLE
refactor podcast filepaths

### DIFF
--- a/db/model.go
+++ b/db/model.go
@@ -8,7 +8,6 @@ package db
 
 import (
 	"fmt"
-	"path"
 	"path/filepath"
 	"sort"
 	"strings"
@@ -134,7 +133,7 @@ func (t *Track) AbsPath() string {
 	if t.Album == nil {
 		return ""
 	}
-	return path.Join(
+	return filepath.Join(
 		t.Album.RootDir,
 		t.Album.LeftPath,
 		t.Album.RightPath,
@@ -146,7 +145,7 @@ func (t *Track) RelPath() string {
 	if t.Album == nil {
 		return ""
 	}
-	return path.Join(
+	return filepath.Join(
 		t.Album.LeftPath,
 		t.Album.RightPath,
 		t.Filename,
@@ -354,10 +353,11 @@ type Podcast struct {
 	Title        string
 	Description  string
 	ImageURL     string
-	ImagePath    string
+	Image        string
 	Error        string
 	Episodes     []*PodcastEpisode
 	AutoDownload PodcastAutoDownload
+	RootDir      string
 }
 
 func (p *Podcast) SID() *specid.ID {
@@ -387,11 +387,10 @@ type PodcastEpisode struct {
 	Bitrate     int
 	Length      int
 	Size        int
-	Path        string
 	Filename    string
 	Status      PodcastEpisodeStatus
 	Error       string
-	AbsP        string `gorm:"-"` // TODO: not this. instead we need some consistent way to get the AbsPath for both tracks and podcast episodes. or just files in general
+	Podcast     *Podcast
 }
 
 func (pe *PodcastEpisode) AudioLength() int  { return pe.Length }
@@ -418,7 +417,10 @@ func (pe *PodcastEpisode) MIME() string {
 }
 
 func (pe *PodcastEpisode) AbsPath() string {
-	return pe.AbsP
+	if pe.Podcast == nil {
+		return ""
+	}
+	return filepath.Join(pe.Podcast.RootDir, pe.Filename)
 }
 
 type Bookmark struct {

--- a/fileutil/fileutil.go
+++ b/fileutil/fileutil.go
@@ -1,0 +1,56 @@
+// TODO: this package shouldn't really exist. we can usually just attempt our normal filesystem operations
+// and handle errors atomically. eg.
+// - Safe could instead be try create file, handle error
+// - Unique could be try create file, on err create file (1), etc
+package fileutil
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+)
+
+var nonAlphaNumExpr = regexp.MustCompile("[^a-zA-Z0-9_.]+")
+
+func Safe(filename string) string {
+	filename = nonAlphaNumExpr.ReplaceAllString(filename, "")
+	return filename
+}
+
+// try to find a unqiue file (or dir) name. incrementing like "example (1)"
+func Unique(base, filename string) (string, error) {
+	return unique(base, filename, 0)
+}
+
+func unique(base, filename string, count uint) (string, error) {
+	var suffix string
+	if count > 0 {
+		suffix = fmt.Sprintf(" (%d)", count)
+	}
+	path := base + suffix
+	if filename != "" {
+		noExt := strings.TrimSuffix(filename, filepath.Ext(filename))
+		path = filepath.Join(base, noExt+suffix+filepath.Ext(filename))
+	}
+	_, err := os.Stat(path)
+	if os.IsNotExist(err) {
+		return path, nil
+	}
+	if err != nil {
+		return "", err
+	}
+	return unique(base, filename, count+1)
+}
+
+func First(path ...string) (string, error) {
+	var err error
+	for _, p := range path {
+		_, err = os.Stat(p)
+		if err == nil {
+			return p, nil
+		}
+	}
+	return "", err
+}

--- a/fileutil/fileutil_test.go
+++ b/fileutil/fileutil_test.go
@@ -1,0 +1,56 @@
+package fileutil
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestUniquePath(t *testing.T) {
+	unq := func(base, filename string, count uint) string {
+		r, err := unique(base, filename, count)
+		require.NoError(t, err)
+		return r
+	}
+
+	require.Equal(t, "test/wow.mp3", unq("test", "wow.mp3", 0))
+	require.Equal(t, "test/wow (1).mp3", unq("test", "wow.mp3", 1))
+	require.Equal(t, "test/wow (2).mp3", unq("test", "wow.mp3", 2))
+
+	require.Equal(t, "test", unq("test", "", 0))
+	require.Equal(t, "test (1)", unq("test", "", 1))
+
+	base := filepath.Join(t.TempDir(), "a")
+
+	require.NoError(t, os.MkdirAll(base, os.ModePerm))
+
+	next := base + " (1)"
+	require.Equal(t, next, unq(base, "", 0))
+
+	require.NoError(t, os.MkdirAll(next, os.ModePerm))
+
+	next = base + " (2)"
+	require.Equal(t, next, unq(base, "", 0))
+
+	_, err := os.Create(filepath.Join(base, "test.mp3"))
+	require.NoError(t, err)
+	require.Equal(t, filepath.Join(base, "test (1).mp3"), unq(base, "test.mp3", 0))
+}
+
+func TestFirst(t *testing.T) {
+	base := t.TempDir()
+	name := filepath.Join(base, "test")
+	_, err := os.Create(name)
+	require.NoError(t, err)
+
+	p := func(name string) string {
+		return filepath.Join(base, name)
+	}
+
+	r, err := First(p("one"), p("two"), p("test"), p("four"))
+	require.NoError(t, err)
+	require.Equal(t, p("test"), r)
+
+}

--- a/podcasts/podcasts_test.go
+++ b/podcasts/podcasts_test.go
@@ -1,20 +1,69 @@
 package podcasts
 
 import (
-	"os"
+	"bytes"
+	_ "embed"
+	"path/filepath"
 	"testing"
 	"time"
 
 	"github.com/mmcdole/gofeed"
+	"github.com/stretchr/testify/require"
+	"go.senan.xyz/gonic/db"
+	"go.senan.xyz/gonic/mockfs"
 )
+
+//go:embed testdata/rss.new
+var testRSS []byte
+
+func TestPodcastsAndEpisodesWithSameName(t *testing.T) {
+	t.Skip("requires network access")
+
+	m := mockfs.New(t)
+	require := require.New(t)
+
+	base := t.TempDir()
+	podcasts := New(m.DB(), base, m.TagReader())
+
+	fp := gofeed.NewParser()
+	newFeed, err := fp.Parse(bytes.NewReader(testRSS))
+	if err != nil {
+		t.Fatalf("parse test data: %v", err)
+	}
+
+	podcast, err := podcasts.AddNewPodcast("file://testdata/rss.new", newFeed)
+	require.NoError(err)
+
+	require.Equal(podcast.RootDir, filepath.Join(base, "InternetBox"))
+
+	podcast, err = podcasts.AddNewPodcast("file://testdata/rss.new", newFeed)
+	require.NoError(err)
+
+	// check we made a unique podcast name
+	require.Equal(podcast.RootDir, filepath.Join(base, "InternetBox (1)"))
+
+	podcastEpisodes, err := podcasts.GetNewestPodcastEpisodes(10)
+	require.NoError(err)
+	require.Greater(len(podcastEpisodes), 0)
+
+	var pe []*db.PodcastEpisode
+	require.NoError(m.DB().Order("id").Find(&pe, "podcast_id=? AND title=?", podcast.ID, "Episode 126").Error)
+	require.Len(pe, 2)
+
+	require.NoError(podcasts.DownloadEpisode(pe[0].ID))
+	require.NoError(podcasts.DownloadEpisode(pe[1].ID))
+
+	require.NoError(m.DB().Order("id").Preload("Podcast").Find(&pe, "podcast_id=? AND title=?", podcast.ID, "Episode 126").Error)
+	require.Len(pe, 2)
+
+	// check we made a unique podcast episode names
+	require.Equal("InternetBoxEpisode126.mp3", pe[0].Filename)
+	require.Equal("InternetBoxEpisode126 (1).mp3", pe[1].Filename)
+}
 
 func TestGetMoreRecentEpisodes(t *testing.T) {
 	fp := gofeed.NewParser()
-	newFile, err := os.Open("testdata/rss.new")
-	if err != nil {
-		t.Fatalf("open test data: %v", err)
-	}
-	newFeed, err := fp.Parse(newFile)
+	newFeed, err := fp.Parse(bytes.NewReader(testRSS))
 	if err != nil {
 		t.Fatalf("parse test data: %v", err)
 	}

--- a/podcasts/testdata/rss.new
+++ b/podcasts/testdata/rss.new
@@ -2,7 +2,7 @@
 <rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom" xmlns:cc="http://web.resource.org/cc/" xmlns:itunes="http://www.itunes.com/dtds/podcast-1.0.dtd" xmlns:media="http://search.yahoo.com/mrss/" xmlns:content="http://purl.org/rss/1.0/modules/content/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
 	<channel>
 		<atom:link href="https://internetbox.libsyn.com/rss" rel="self" type="application/rss+xml"/>
-		<title>Internet Box</title>
+		<title>Internet Box!</title>
 		<pubDate>Mon, 01 Apr 2019 04:35:43 +0000</pubDate>
 		<lastBuildDate>Sun, 10 Jan 2021 00:07:33 +0000</lastBuildDate>
 		<generator>Libsyn WebEngine 2.0</generator>
@@ -70,7 +70,23 @@
 			<pubDate>Mon, 27 Jun 2016 06:33:43 +0000</pubDate>
 			<guid isPermaLink="false"><![CDATA[d5113fc98b7baf005bf66b225b166ee0]]></guid>
 			<link><![CDATA[http://internetboxpodcast.com/episode-126/]]></link>
-			<itunes:image href="https://ssl-static.libsyn.com/p/assets/d/d/3/3/dd338b309838f617/iTunes.png" />
+			<itunes:image href="file://testdata/cover.png" />
+			<description><![CDATA[<p>The Internet Box is clicking this week!</p>]]></description>
+			<content:encoded><![CDATA[<p>The Internet Box is clicking this week!</p>]]></content:encoded>
+			<enclosure length="66139165" type="audio/mpeg" url="https://traffic.libsyn.com/secure/internetbox/InternetBoxEpisode126.mp3?dest-id=79492" />
+			<itunes:duration>01:20:42</itunes:duration>
+			<itunes:explicit>yes</itunes:explicit>
+			<itunes:keywords>box,2,factory,internet,pizza,future,robots,season,farts,cake,via,reddit,313,vorarephilia</itunes:keywords>
+			<itunes:subtitle><![CDATA[The Internet Box is clicking this week!]]></itunes:subtitle>
+		</item>
+
+		<!-- dupe episode name -->
+		<item>
+			<title>Episode 126</title>
+			<pubDate>Mon, 27 Jun 2016 06:33:43 +0000</pubDate>
+			<guid isPermaLink="false"><![CDATA[d5113fc98b7baf005bf66b225b166ee0]]></guid>
+			<link><![CDATA[http://internetboxpodcast.com/episode-126/]]></link>
+			<itunes:image href="file://testdata/cover.png" />
 			<description><![CDATA[<p>The Internet Box is clicking this week!</p>]]></description>
 			<content:encoded><![CDATA[<p>The Internet Box is clicking this week!</p>]]></content:encoded>
 			<enclosure length="66139165" type="audio/mpeg" url="https://traffic.libsyn.com/secure/internetbox/InternetBoxEpisode126.mp3?dest-id=79492" />

--- a/server/ctrlsubsonic/ctrl_test.go
+++ b/server/ctrlsubsonic/ctrl_test.go
@@ -8,7 +8,6 @@ import (
 	"net/http/httptest"
 	"net/url"
 	"os"
-	"path"
 	"path/filepath"
 	"regexp"
 	"strings"
@@ -48,7 +47,7 @@ func makeGoldenPath(test string) string {
 	snake := testCamelExpr.ReplaceAllString(test, "${1}_${2}")
 	lower := strings.ToLower(snake)
 	relPath := strings.ReplaceAll(lower, "/", "_")
-	return path.Join("testdata", relPath)
+	return filepath.Join("testdata", relPath)
 }
 
 func makeHTTPMock(query url.Values) (*httptest.ResponseRecorder, *http.Request) {

--- a/server/ctrlsubsonic/handlers_common.go
+++ b/server/ctrlsubsonic/handlers_common.go
@@ -184,11 +184,7 @@ func (c *Controller) ServeGetPlayQueue(r *http.Request) *spec.Response {
 			c.DB.
 				Where("id=?", id.Value).
 				Find(&pe)
-			p := db.Podcast{}
-			c.DB.
-				Where("id=?", pe.PodcastID).
-				Find(&p)
-			sub.PlayQueue.List[i] = spec.NewTCPodcastEpisode(&pe, &p)
+			sub.PlayQueue.List[i] = spec.NewTCPodcastEpisode(&pe)
 			sub.PlayQueue.List[i].TranscodeMeta = transcodeMeta
 		}
 	}
@@ -300,7 +296,7 @@ func (c *Controller) ServeJukebox(r *http.Request) *spec.Response { // nolint:go
 	trackPaths := func(ids []specid.ID) ([]string, error) {
 		var paths []string
 		for _, id := range ids {
-			r, err := specidpaths.Locate(c.DB, c.PodcastsPath, id)
+			r, err := specidpaths.Locate(c.DB, id)
 			if err != nil {
 				return nil, fmt.Errorf("find track by id: %w", err)
 			}

--- a/server/ctrlsubsonic/spec/construct_by_folder.go
+++ b/server/ctrlsubsonic/spec/construct_by_folder.go
@@ -1,7 +1,7 @@
 package spec
 
 import (
-	"path"
+	"path/filepath"
 	"strings"
 
 	"go.senan.xyz/gonic/db"
@@ -62,7 +62,7 @@ func NewTCTrackByFolder(t *db.Track, parent *db.Album) *TrackChild {
 		Title:       t.TagTitle,
 		TrackNumber: t.TagTrackNumber,
 		DiscNumber:  t.TagDiscNumber,
-		Path: path.Join(
+		Path: filepath.Join(
 			parent.LeftPath,
 			parent.RightPath,
 			t.Filename,
@@ -95,20 +95,23 @@ func NewTCTrackByFolder(t *db.Track, parent *db.Album) *TrackChild {
 	return trCh
 }
 
-func NewTCPodcastEpisode(pe *db.PodcastEpisode, parent *db.Podcast) *TrackChild {
+func NewTCPodcastEpisode(pe *db.PodcastEpisode) *TrackChild {
 	trCh := &TrackChild{
 		ID:          pe.SID(),
 		ContentType: pe.MIME(),
 		Suffix:      pe.Ext(),
 		Size:        pe.Size,
 		Title:       pe.Title,
-		Path:        pe.Path,
-		ParentID:    parent.SID(),
+		ParentID:    pe.SID(),
 		Duration:    pe.Length,
 		Bitrate:     pe.Bitrate,
 		IsDir:       false,
 		Type:        "podcastepisode",
 		CreatedAt:   pe.CreatedAt,
+	}
+	if pe.Podcast != nil {
+		trCh.ParentID = pe.Podcast.SID()
+		trCh.Path = pe.AbsPath()
 	}
 	return trCh
 }

--- a/server/ctrlsubsonic/spec/construct_by_tags.go
+++ b/server/ctrlsubsonic/spec/construct_by_tags.go
@@ -1,7 +1,7 @@
 package spec
 
 import (
-	"path"
+	"path/filepath"
 	"sort"
 	"strings"
 
@@ -61,7 +61,7 @@ func NewTrackByTags(t *db.Track, album *db.Album) *TrackChild {
 		Artist:      t.TagTrackArtist,
 		TrackNumber: t.TagTrackNumber,
 		DiscNumber:  t.TagDiscNumber,
-		Path: path.Join(
+		Path: filepath.Join(
 			album.LeftPath,
 			album.RightPath,
 			t.Filename,

--- a/server/ctrlsubsonic/spec/construct_podcast.go
+++ b/server/ctrlsubsonic/spec/construct_podcast.go
@@ -1,13 +1,13 @@
 package spec
 
 import (
-	"jaytaylor.com/html2text"
 	"go.senan.xyz/gonic/db"
+	"jaytaylor.com/html2text"
 )
 
 func NewPodcastChannel(p *db.Podcast) *PodcastChannel {
 	desc, err := html2text.FromString(p.Description, html2text.Options{TextOnly: true})
-	if (err != nil) {
+	if err != nil {
 		desc = ""
 	}
 	ret := &PodcastChannel{
@@ -26,31 +26,34 @@ func NewPodcastChannel(p *db.Podcast) *PodcastChannel {
 	return ret
 }
 
-func NewPodcastEpisode(e *db.PodcastEpisode) *PodcastEpisode {
-	if e == nil {
+func NewPodcastEpisode(pe *db.PodcastEpisode) *PodcastEpisode {
+	if pe == nil {
 		return nil
 	}
-	desc, err := html2text.FromString(e.Description, html2text.Options{TextOnly: true})
-	if (err != nil) {
+	desc, err := html2text.FromString(pe.Description, html2text.Options{TextOnly: true})
+	if err != nil {
 		desc = ""
 	}
-	return &PodcastEpisode{
-		ID:          e.SID(),
-		StreamID:    e.SID(),
-		ContentType: e.MIME(),
-		ChannelID:   e.PodcastSID(),
-		Title:       e.Title,
+	r := &PodcastEpisode{
+		ID:          pe.SID(),
+		StreamID:    pe.SID(),
+		ContentType: pe.MIME(),
+		ChannelID:   pe.PodcastSID(),
+		Title:       pe.Title,
 		Description: desc,
-		Status:      string(e.Status),
-		CoverArt:    e.PodcastSID(),
-		PublishDate: *e.PublishDate,
+		Status:      string(pe.Status),
+		CoverArt:    pe.PodcastSID(),
+		PublishDate: *pe.PublishDate,
 		Genre:       "Podcast",
-		Duration:    e.Length,
-		Year:        e.PublishDate.Year(),
-		Suffix:      formatExt(e.Ext()),
-		BitRate:     e.Bitrate,
+		Duration:    pe.Length,
+		Year:        pe.PublishDate.Year(),
+		Suffix:      formatExt(pe.Ext()),
+		BitRate:     pe.Bitrate,
 		IsDir:       false,
-		Path:        e.Path,
-		Size:        e.Size,
+		Size:        pe.Size,
 	}
+	if pe.Podcast != nil {
+		r.Path = pe.AbsPath()
+	}
+	return r
 }


### PR DESCRIPTION
- auto increment podcast names too
- store podcast root dirs (like we do for music)
- drop podcast episode "path" column

TODO:
- [x] fix specid
- [x] migration code
- [x] move safe filename backfill code to migrations so we only have to do it once
- [x] test

fixes #350
