### PR TITLE
fix(subsonic): songCount and albumCount in genre objects is required

### DIFF
--- a/server/ctrlsubsonic/spec/spec.go
+++ b/server/ctrlsubsonic/spec/spec.go
@@ -309,9 +309,9 @@ type Genres struct {
 }
 
 type Genre struct {
-	Name       string `xml:",chardata"                 json:"value"`
-	SongCount  int    `xml:"songCount,attr,omitempty"  json:"songCount,omitempty"`
-	AlbumCount int    `xml:"albumCount,attr,omitempty" json:"albumCount,omitempty"`
+	Name       string `xml:",chardata"       json:"value"`
+	SongCount  int    `xml:"songCount,attr"  json:"songCount"`
+	AlbumCount int    `xml:"albumCount,attr" json:"albumCount"`
 }
 
 type PlayQueue struct {


### PR DESCRIPTION
The `songCount` and `albumCount` attributes are required according the subsonic api xml file. Noticed this in the airsonic-refix client where the genres page would sort the genres wrong if the value is left out instead of 0.