### PR TITLE
refactor(scanner): make the watcher a little easier to reason about

### DIFF
--- a/cmd/gonic/gonic.go
+++ b/cmd/gonic/gonic.go
@@ -300,12 +300,13 @@ func main() {
 
 		defer logJob("scan watcher")()
 
+		done := make(chan struct{})
 		errgrp.Go(func() error {
 			<-ctx.Done()
-			scannr.CancelWatch()
+			done <- struct{}{}
 			return nil
 		})
-		return scannr.ExecuteWatch()
+		return scannr.ExecuteWatch(done)
 	})
 
 	errgrp.Go(func() error {

--- a/scanner/scanner_test.go
+++ b/scanner/scanner_test.go
@@ -487,6 +487,23 @@ func TestSymlinkedSubdiscs(t *testing.T) {
 	assert.NotZero(t, info.ModTime()) // track resolves
 }
 
+func TestSymlinkEscapesMusicDirs(t *testing.T) {
+	t.Parallel()
+	m := mockfs.NewWithDirs(t, []string{"scandir"})
+
+	require.NoError(t, os.MkdirAll(filepath.Join(m.TmpDir(), "otherdir", "artist", "album-test"), os.ModePerm))
+	require.NoError(t, os.Symlink(
+		filepath.Join(m.TmpDir(), "otherdir", "artist"),
+		filepath.Join(m.TmpDir(), "scandir", "artist"),
+	))
+
+	m.ScanAndClean()
+
+	var albums []*db.Album
+	require.NoError(t, m.DB().Find(&albums).Error)
+	require.Len(t, albums, 3)
+}
+
 func TestTagErrors(t *testing.T) {
 	t.Parallel()
 	m := mockfs.New(t)


### PR DESCRIPTION
hiya @brian-doherty , i was reading the scanner code again today, and since it had been a while it took me a little while to grasp it again. i'm wondering what you think about these changes that i've found to help a me a bit

- pass only an "absPath" arg to scanCallback and watchCallback instead of "absPath" and "dir" (musicDir). the callbacks can deduce the root dir themselves, and the two args have always been confusing, even for the original scanCallback
- delete the watch stuff from the main scanner struct. it seems we don't need watchMap given above^ and the others can be centralised to ExecuteWatch
- update some names so that its clear we're doing some event batching

thoughts? thanks!
