### PR TITLE
Fix listenbrainz track length submission and include submission client details

### DIFF
--- a/listenbrainz/listenbrainz.go
+++ b/listenbrainz/listenbrainz.go
@@ -10,6 +10,7 @@ import (
 	"net/http/httputil"
 	"time"
 
+	"go.senan.xyz/gonic"
 	"go.senan.xyz/gonic/db"
 	"go.senan.xyz/gonic/scrobble"
 )
@@ -44,9 +45,10 @@ func (c *Client) Scrobble(user db.User, track scrobble.Track, stamp time.Time, s
 	payload := &Payload{
 		TrackMetadata: &TrackMetadata{
 			AdditionalInfo: &AdditionalInfo{
-				TrackNumber:   int(track.TrackNumber),
-				RecordingMBID: track.MusicBrainzID,
-				Duration:      int(track.Duration.Seconds()),
+				TrackNumber:      int(track.TrackNumber),
+				RecordingMBID:    track.MusicBrainzID,
+				Duration:         int(track.Duration.Seconds()),
+				SubmissionClient: gonic.Name,
 			},
 			ArtistName:  track.Artist,
 			TrackName:   track.Track,

--- a/listenbrainz/listenbrainz.go
+++ b/listenbrainz/listenbrainz.go
@@ -46,7 +46,7 @@ func (c *Client) Scrobble(user db.User, track scrobble.Track, stamp time.Time, s
 			AdditionalInfo: &AdditionalInfo{
 				TrackNumber:   int(track.TrackNumber),
 				RecordingMBID: track.MusicBrainzID,
-				TrackLength:   int(track.Duration.Seconds()),
+				Duration:      int(track.Duration.Seconds()),
 			},
 			ArtistName:  track.Artist,
 			TrackName:   track.Track,

--- a/listenbrainz/listenbrainz_test.go
+++ b/listenbrainz/listenbrainz_test.go
@@ -37,7 +37,14 @@ func TestScrobble(t *testing.T) {
 
 	err := client.Scrobble(
 		db.User{ListenBrainzURL: "https://listenbrainz.org", ListenBrainzToken: "token1"},
-		scrobble.Track{Track: "title", Artist: "artist", Album: "album", TrackNumber: 1},
+		scrobble.Track{
+			Track:         "title",
+			Artist:        "artist",
+			Album:         "album",
+			TrackNumber:   1,
+			Duration:      242 * time.Second,
+			MusicBrainzID: "00000000-0000-0000-0000-000000000000",
+		},
 		time.Unix(1683804525, 0),
 		true,
 	)

--- a/listenbrainz/model.go
+++ b/listenbrainz/model.go
@@ -9,10 +9,11 @@ type (
 	}
 
 	AdditionalInfo struct {
-		TrackNumber   int    `json:"tracknumber,omitempty"`
-		TrackMBID     string `json:"track_mbid,omitempty"`
-		RecordingMBID string `json:"recording_mbid,omitempty"`
-		Duration      int    `json:"duration,omitempty"`
+		TrackNumber      int    `json:"tracknumber,omitempty"`
+		TrackMBID        string `json:"track_mbid,omitempty"`
+		RecordingMBID    string `json:"recording_mbid,omitempty"`
+		Duration         int    `json:"duration,omitempty"`
+		SubmissionClient string `json:"submission_client,omitempty"`
 	}
 
 	TrackMetadata struct {

--- a/listenbrainz/model.go
+++ b/listenbrainz/model.go
@@ -12,7 +12,7 @@ type (
 		TrackNumber   int    `json:"tracknumber,omitempty"`
 		TrackMBID     string `json:"track_mbid,omitempty"`
 		RecordingMBID string `json:"recording_mbid,omitempty"`
-		TrackLength   int    `json:"track_length,omitempty"`
+		Duration      int    `json:"duration,omitempty"`
 	}
 
 	TrackMetadata struct {

--- a/listenbrainz/testdata/submit_listens_request.json
+++ b/listenbrainz/testdata/submit_listens_request.json
@@ -6,6 +6,8 @@
             "track_metadata": {
                 "additional_info": {
                     "tracknumber": 1,
+                    "duration": 242,
+                    "recording_mbid": "00000000-0000-0000-0000-000000000000",
                     "submission_client": "gonic"
                 },
                 "artist_name": "artist",

--- a/listenbrainz/testdata/submit_listens_request.json
+++ b/listenbrainz/testdata/submit_listens_request.json
@@ -5,7 +5,8 @@
             "listened_at": 1683804525,
             "track_metadata": {
                 "additional_info": {
-                    "tracknumber": 1
+                    "tracknumber": 1,
+                    "submission_client": "gonic"
                 },
                 "artist_name": "artist",
                 "track_name": "title",


### PR DESCRIPTION
This fixes the track length submission for ListenBrainz. ListenBrainz defines the fields `duration` and `duration_ms` for this, see https://listenbrainz.readthedocs.io/en/latest/users/json.html . Without this information LB will not show a track length. It might also prematurely remove the "now playing" notification for longer tracks.

As I understand from the code the track length is in seconds precision, hence the `duration` field is being used. `duration_ms`  would be for milliseconds.

This PR also includes the fields `submission_client` as defined in the LB API docs linked above.
