### PR TITLE
Fix bug with checking path prefixes

### DIFF
--- a/server/ctrlsubsonic/specidpaths/specidpaths.go
+++ b/server/ctrlsubsonic/specidpaths/specidpaths.go
@@ -54,8 +54,9 @@ func Lookup(dbc *db.DB, musicPaths []string, podcastsPath string, path string) (
 
 	var musicPath string
 	for _, mp := range musicPaths {
-		if strings.HasPrefix(path, mp+"/") {
+		if strings.HasPrefix(path, filepath.Clean(mp)+string(filepath.Separator) /* ensure trailing */) {
 			musicPath = mp
+			break
 		}
 	}
 	if musicPath == "" {

--- a/server/ctrlsubsonic/specidpaths/specidpaths.go
+++ b/server/ctrlsubsonic/specidpaths/specidpaths.go
@@ -3,7 +3,6 @@ package specidpaths
 import (
 	"errors"
 	"path/filepath"
-	"sort"
 	"strings"
 
 	"go.senan.xyz/gonic/db"

--- a/server/ctrlsubsonic/specidpaths/specidpaths.go
+++ b/server/ctrlsubsonic/specidpaths/specidpaths.go
@@ -54,7 +54,7 @@ func Lookup(dbc *db.DB, musicPaths []string, podcastsPath string, path string) (
 
 	var musicPath string
 	for _, mp := range musicPaths {
-		if strings.HasPrefix(path, mp + "/") {
+		if strings.HasPrefix(path, mp+"/") {
 			musicPath = mp
 		}
 	}

--- a/server/ctrlsubsonic/specidpaths/specidpaths.go
+++ b/server/ctrlsubsonic/specidpaths/specidpaths.go
@@ -54,9 +54,8 @@ func Lookup(dbc *db.DB, musicPaths []string, podcastsPath string, path string) (
 	}
 
 	var musicPath string
-	sort.Sort(sort.Reverse(sort.StringSlice(musicPaths)))
 	for _, mp := range musicPaths {
-		if strings.HasPrefix(path, mp) {
+		if strings.HasPrefix(path, mp + '/') {
 			musicPath = mp
 		}
 	}

--- a/server/ctrlsubsonic/specidpaths/specidpaths.go
+++ b/server/ctrlsubsonic/specidpaths/specidpaths.go
@@ -55,7 +55,7 @@ func Lookup(dbc *db.DB, musicPaths []string, podcastsPath string, path string) (
 
 	var musicPath string
 	for _, mp := range musicPaths {
-		if strings.HasPrefix(path, mp + '/') {
+		if strings.HasPrefix(path, mp + "/") {
 			musicPath = mp
 		}
 	}

--- a/server/ctrlsubsonic/specidpaths/specidpaths.go
+++ b/server/ctrlsubsonic/specidpaths/specidpaths.go
@@ -3,6 +3,7 @@ package specidpaths
 import (
 	"errors"
 	"path/filepath"
+	"sort"
 	"strings"
 
 	"go.senan.xyz/gonic/db"
@@ -53,6 +54,7 @@ func Lookup(dbc *db.DB, musicPaths []string, podcastsPath string, path string) (
 	}
 
 	var musicPath string
+	sort.Sort(sort.Reverse(sort.StringSlice(musicPaths)))
 	for _, mp := range musicPaths {
 		if strings.HasPrefix(path, mp) {
 			musicPath = mp


### PR DESCRIPTION
As discussed on IRC, if you have two paths like
```
/Music/Tagged
/Music/TaggedManual
```

it may grab the wrong musicPath from checking prefixes.

Add a `/` to the music path to ensure that the prefix is a real dir, and not a partial name to a dir