### PR TITLE
Bugfix: Remediation for Panic! at the Parser

### DIFF
--- a/scanner/scanner.go
+++ b/scanner/scanner.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
+	"slices"
 	"sort"
 	"strconv"
 	"strings"
@@ -714,6 +715,10 @@ func parseMulti(parser tagcommon.Info, setting MultiValueSetting, getMulti func(
 	default:
 		parts = []string{get(parser)}
 	}
+	// trim potential empty strings from delimited results
+	parts = slices.DeleteFunc(parts, func(s string) bool {
+		return s == ""
+	})
 	for i := range parts {
 		parts[i] = strings.TrimSpace(parts[i])
 	}

--- a/server/ctrlsubsonic/handlers_common.go
+++ b/server/ctrlsubsonic/handlers_common.go
@@ -518,6 +518,11 @@ func getMusicFolder(musicPaths []MusicPath, p params.Params) string {
 }
 
 func lowerUDecOrHash(in string) string {
+	defer func() {
+		if err := recover(); err != nil {
+			log.Println("unable to index parsed object:", err)
+		}
+	}()
 	lower := unicode.ToLower(rune(in[0]))
 	if !unicode.IsLetter(lower) {
 		return "#"


### PR DESCRIPTION
Hi! This project is pretty great, thanks for it.

After scanning an initial set of albums, attempts to bring up my artist list (via both Tempo/Subsonic) would fail with a network error. On reviewing gonic logs, I found the following:
```
gonic_1  | 2023/12/30 19:12:29 http: panic serving ###.###.###.###:58864: runtime error: index 
out of range [0] with length 0                                                                
gonic_1  | goroutine 89959 [running]:                                                         
gonic_1  | net/http.(*conn).serve.func1()                                                     
gonic_1  |      /usr/local/go/src/net/http/server.go:1868 +0xb9                               
gonic_1  | panic({0xbda260?, 0xc000002a08?})                                                  
gonic_1  |      /usr/local/go/src/runtime/panic.go:920 +0x270                                 
gonic_1  | go.senan.xyz/gonic/server/ctrlsubsonic.lowerUDecOrHash({0x0?, 0xb37460?})          
gonic_1  |      /src/server/ctrlsubsonic/handlers_common.go:517 +0x90                         
gonic_1  | go.senan.xyz/gonic/server/ctrlsubsonic.(*Controller).ServeGetArtists(0xc000756000, 
0xc001932300)                                                                                 
gonic_1  |      /src/server/ctrlsubsonic/handlers_by_tags.go:47 +0x5fe                        
gonic_1  | go.senan.xyz/gonic/server/ctrlsubsonic.New.resp.func37({0xd9ea48, 0xc000392000}, 
0x
...
```
After some further tests I isolated this down to a single album and artist - [N O Ć [EP]' by DON'T//BE// ⚜⚜⚜](https://dontbe.bandcamp.com/album/n-o-ep) - the failure resulting from the double-slashes in the artist name. The current _multiParser_ function (with configured '/' delim) will split the double-slash into an empty string. When this `""` reaches the unicode index check (_lowerUDecOrHash_), it panics with the above and breaks the response.

This PR implements two remediations:
- Adds a function that will delete any/all empty strings from the parse after a delimiter split.
- Adds a general recovery to the index check, as the (now minimized) breakage of an indexed item is likely preferable than loss of the full artist index response for a client.

While the above restores the artist index, this particular artist will still be split into three separate objects (albeit functionally). Perhaps not ideal, but also an extremely niche case that could likely be addressed at a later time. I'd otherwise expect this to be seen if someone had a typo in their tags.