### PR TITLE
Add playlists with no user to admin's playlist list.

### DIFF
--- a/playlist/playlist.go
+++ b/playlist/playlist.go
@@ -99,7 +99,7 @@ func (s *Store) Read(relPath string) (*Playlist, error) {
 
 	playlist.UserID, err = userIDFromPath(relPath)
 	if err != nil {
-		return nil, fmt.Errorf("convert id to str: %w", err)
+		playlist.UserID = 1
 	}
 
 	playlist.Name = strings.TrimSuffix(filepath.Base(relPath), filepath.Ext(relPath))


### PR DESCRIPTION
This is carrying on from the various tickets under which playlists have been discussed.

For reasons well-known (#306, #311, #307, #311... but mainly #306), the Subsonic API forces playlists to be by user ID. The solution in gonic was to expect a directory layout with `<playlistpath>/<userid>/.../<whatever>.m3u`. This is inconvenient for users for whom gonic is not the only application using the playlist directory, and maybe not even the main one, an inconvenience exacerbated by the fact that `fs.DirEntry.IsDir()` returns false for directory symlinks.

This extremely trivial change does one thing: instead of throwing an error when the directory structure does not contain user IDs as the second element in the path, it merely adds those playlists to the admin's playlist list. This change has two impacts:

1. These playlists would otherwise be entirely ignored by gonic. It's possible some users are leveraging that to have playlists in the same directory used by some other program that they intentionally hide from gonic.
2. admin might suddenly see a bunch of playlists they didn't before, because there were playlists that were being ignored

What it accomplishes is that it allows gonic to share playlists with all of the other non-Subsonic apps that _don't_ put playlists into int-named subdirectories.