### PR TITLE
chore: update to Alpine 3.19

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.18 AS builder-taglib
+FROM alpine:3.19 AS builder-taglib
 WORKDIR /tmp
 COPY alpine/taglib/APKBUILD .
 RUN apk update && \
@@ -26,7 +26,7 @@ RUN go mod download
 COPY . .
 RUN GOOS=linux go build -o gonic cmd/gonic/gonic.go
 
-FROM alpine:3.18
+FROM alpine:3.19
 LABEL org.opencontainers.image.source https://github.com/sentriz/gonic
 RUN apk add -U --no-cache \
     ffmpeg \

--- a/alpine/taglib/APKBUILD
+++ b/alpine/taglib/APKBUILD
@@ -1,13 +1,13 @@
 # Contributor: Leo <thinkabit.ukim@gmail.com>
 # Maintainer: Natanael Copa <ncopa@alpinelinux.org>
 pkgname=taglib2
-pkgver=2.0
+pkgver=2.0.1
 pkgrel=0
 pkgdesc="Library for reading and editing metadata of several popular audio formats"
 url="https://taglib.github.io/"
 arch="all"
 license="LGPL-2.1-only OR MPL-1.1"
-makedepends="zlib-dev utfcpp cmake samurai"
+makedepends="zlib-dev git cmake samurai"
 checkdepends="cppunit-dev"
 subpackages="
 	$pkgname-dev
@@ -23,6 +23,8 @@ builddir="$srcdir/taglib-$pkgver"
 #     - CVE-2018-11439
 
 build() {
+    git clone --depth=1 --branch v3.2.5 https://github.com/nemtrif/utfcpp.git 3rdparty/utfcpp
+
     CFLAGS="$CFLAGS -flto=auto" \
         CXXFLAGS="$CXXFLAGS -flto=auto" \
         cmake -B build -G Ninja \
@@ -30,7 +32,7 @@ build() {
         -DCMAKE_BUILD_TYPE=MinSizeRel \
         -DWITH_ZLIB=ON \
         -DBUILD_SHARED_LIBS=ON \
-        -DBUILD_EXAMPLES=ON \
+        -DBUILD_EXAMPLES=OFF \
         -DBUILD_TESTING="$(want_check && echo ON || echo OFF)" \
         -DVISIBILITY_HIDDEN=ON
     cmake --build build
@@ -51,5 +53,5 @@ _lib() {
 }
 
 sha512sums="
-099d02b2eab033f5702a8cb03e70752d7523c6f8c2f3eebdd0bcd939eafbdca3f2a6c82452983904b5822cfa45f2707ed866c3419508df9d43bf5c0b3a476f6c  taglib-2.0.tar.gz
+25ee89293a96d7f8dca6276f822bdaef01fd98503b78c20ffeac8e1d9821de7273a5127146aa798d304c6a995cb2b7229a205aff1cc261b5d4fa9e499dda0439  taglib-2.0.1.tar.gz
 "


### PR DESCRIPTION
Installing taglib2 is now doubly painful, because Alpine 3.19 packages utfcpp 4.0.2-r0, which results in this:


> ninja: job failed: /usr/bin/g++ -DHAVE_CONFIG_H -DMAKE_TAGLIB_LIB -I/tmp/src/taglib-2.0.1/build/taglib -I/tmp/src/taglib-2.0.1/taglib -I/tmp/src/taglib-2.0.1/build -I/tmp/src/taglib-2.0.1/taglib/toolkit -I/tmp/src/taglib-2.0.1/taglib/asf -I/tmp/src/taglib-2.0.1/taglib/mpeg -I/tmp/src/taglib-2.0.1/taglib/ogg -I/tmp/src/taglib-2.0.1/taglib/ogg/flac -I/tmp/src/taglib-2.0.1/taglib/flac -I/tmp/src/taglib-2.0.1/taglib/mpc -I/tmp/src/taglib-2.0.1/taglib/mp4 -I/tmp/src/taglib-2.0.1/taglib/ogg/vorbis -I/tmp/src/taglib-2.0.1/taglib/ogg/speex -I/tmp/src/taglib-2.0.1/taglib/ogg/opus -I/tmp/src/taglib-2.0.1/taglib/mpeg/id3v2 -I/tmp/src/taglib-2.0.1/taglib/mpeg/id3v2/frames -I/tmp/src/taglib-2.0.1/taglib/mpeg/id3v1 -I/tmp/src/taglib-2.0.1/taglib/ape -I/tmp/src/taglib-2.0.1/taglib/wavpack -I/tmp/src/taglib-2.0.1/taglib/trueaudio -I/tmp/src/taglib-2.0.1/taglib/riff -I/tmp/src/taglib-2.0.1/taglib/riff/aiff -I/tmp/src/taglib-2.0.1/taglib/riff/wav -I/tmp/src/taglib-2.0.1/taglib/mod -I/tmp/src/taglib-2.0.1/taglib/s3m -I/tmp/src/taglib-2.0.1/taglib/it -I/tmp/src/taglib-2.0.1/taglib/xm -I/tmp/src/taglib-2.0.1/taglib/dsf -I/tmp/src/taglib-2.0.1/taglib/dsdiff -Os -fstack-clash-protection -Wformat -Werror=format-security -D_GLIBCXX_ASSERTIONS=1 -D_LIBCPP_ENABLE_THREAD_SAFETY_ANNOTATIONS=1 -D_LIBCPP_ENABLE_HARDENED_MODE=1 -fno-plt -flto=auto -Wall -Os -DNDEBUG -std=gnu++17 -fPIC -fvisibility=hidden -MD -MT taglib/CMakeFiles/tag.dir/toolkit/tstring.cpp.o -MF taglib/CMakeFiles/tag.dir/toolkit/tstring.cpp.o.d -o taglib/CMakeFiles/tag.dir/toolkit/tstring.cpp.o -c /tmp/src/taglib-2.0.1/taglib/toolkit/tstring.cpp
/tmp/src/taglib-2.0.1/taglib/toolkit/tstring.cpp:31:10: fatal error: utf8.h: No such file or directory
   31 | #include <utf8.h>
>      |          ^~~~~~~~
> compilation terminated.
> ninja: subcommand failed
> &gt;&gt;&gt; ERROR: taglib2: build failed
```