### PR TITLE
Add a covering index on tracks (album_id, length)

### DIFF
--- a/db/migrations.go
+++ b/db/migrations.go
@@ -73,6 +73,7 @@ func (db *DB) Migrate(ctx MigrationContext) error {
 		construct(ctx, "202311082304", migrateTemporaryDisplayAlbumArtist),
 		construct(ctx, "202312110003", migrateAddExtraIndexes),
 		construct(ctx, "202405251900", migrateTrackAddIndexOnAlbumID),
+		construct(ctx, "202406011241", migrateAlbumAddIndexOnParentID),
 	}
 
 	return gormigrate.
@@ -818,5 +819,11 @@ func migrateAddExtraIndexes(tx *gorm.DB, _ MigrationContext) error {
 func migrateTrackAddIndexOnAlbumID(tx *gorm.DB, _ MigrationContext) error {
 	return tx.Exec(`
 		CREATE INDEX idx_tracks_album_id ON "tracks" (album_id, length);
+	`).Error
+}
+
+func migrateAlbumAddIndexOnParentID(tx *gorm.DB, _ MigrationContext) error {
+	return tx.Exec(`
+		CREATE INDEX idx_albums_parent_id ON "albums" (parent_id);
 	`).Error
 }

--- a/db/migrations.go
+++ b/db/migrations.go
@@ -72,6 +72,7 @@ func (db *DB) Migrate(ctx MigrationContext) error {
 		construct(ctx, "202311072309", migrateAlbumInfo),
 		construct(ctx, "202311082304", migrateTemporaryDisplayAlbumArtist),
 		construct(ctx, "202312110003", migrateAddExtraIndexes),
+		construct(ctx, "202405251900", migrateTrackAddIndexOnAlbumID),
 	}
 
 	return gormigrate.
@@ -811,5 +812,11 @@ func migrateAddExtraIndexes(tx *gorm.DB, _ MigrationContext) error {
 		CREATE INDEX idx_album_artists_artist_id ON "album_artists" (artist_id);
 		CREATE INDEX idx_track_artists_artist_id ON "track_artists" (artist_id);
 		CREATE INDEX idx_artist_appearances_album_id ON "artist_appearances" (album_id);
+	`).Error
+}
+
+func migrateTrackAddIndexOnAlbumID(tx *gorm.DB, _ MigrationContext) error {
+	return tx.Exec(`
+		CREATE INDEX idx_tracks_album_id ON "tracks" (album_id, length);
 	`).Error
 }

--- a/handlerutil/handlerutil.go
+++ b/handlerutil/handlerutil.go
@@ -5,6 +5,7 @@ import (
 	"log"
 	"net/http"
 	"strings"
+	"time"
 )
 
 type Middleware func(http.Handler) http.Handler
@@ -30,8 +31,10 @@ func TrimPathSuffix(suffix string) Middleware {
 func Log(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		sw := &statusWriter{ResponseWriter: w}
+		t := time.Now()
 		next.ServeHTTP(sw, r)
-		log.Printf("response %s %s %v", statusToBlock(sw.status), r.Method, r.URL)
+		duration := time.Since(t).Seconds()
+		log.Printf("response [%.3fs] %s %s %v", duration, statusToBlock(sw.status), r.Method, r.URL)
 	})
 }
 

--- a/server/ctrlsubsonic/handlers_by_folder.go
+++ b/server/ctrlsubsonic/handlers_by_folder.go
@@ -31,10 +31,9 @@ func (c *Controller) ServeGetIndexes(r *http.Request) *spec.Response {
 	}
 	var folders []*db.Album
 	c.dbc.
-		Select("*, count(sub.id) child_count").
+		Select("*, (SELECT count(*) FROM albums sub WHERE sub.parent_id=albums.id) child_count").
 		Preload("AlbumStar", "user_id=?", user.ID).
 		Preload("AlbumRating", "user_id=?", user.ID).
-		Joins("LEFT JOIN albums sub ON albums.id=sub.parent_id").
 		Where("albums.parent_id IN ?", rootQ.SubQuery()).
 		Group("albums.id").
 		Order("albums.right_path COLLATE NOCASE").

--- a/server/ctrlsubsonic/handlers_by_folder.go
+++ b/server/ctrlsubsonic/handlers_by_folder.go
@@ -174,8 +174,9 @@ func (c *Controller) ServeGetAlbumList(r *http.Request) *spec.Response {
 	// TODO: think about removing this extra join to count number
 	// of children. it might make sense to store that in the db
 	q.
-		Select("albums.*, count(tracks.id) child_count, sum(tracks.length) duration").
-		Joins("LEFT JOIN tracks ON tracks.album_id=albums.id").
+		Select(`albums.*,
+			(SELECT count(*) FROM tracks WHERE album_id = albums.id) child_count,
+			(SELECT sum(length) FROM tracks WHERE album_id = albums.id) duration`).
 		Group("albums.id").
 		Joins("JOIN album_artists ON album_artists.album_id=albums.id").
 		Offset(params.GetOrInt("offset", 0)).

--- a/server/ctrlsubsonic/handlers_by_tags.go
+++ b/server/ctrlsubsonic/handlers_by_tags.go
@@ -26,11 +26,11 @@ func (c *Controller) ServeGetArtists(r *http.Request) *spec.Response {
 	user := r.Context().Value(CtxUser).(*db.User)
 	var artists []*db.Artist
 	q := c.dbc.
-		Select("*, count(album_artists.album_id) album_count").
+		Select("artists.*, artist_infos.image_url, count(album_artists.album_id) album_count").
+		Joins("LEFT JOIN artist_infos ON artist_infos.id=artists.id").
 		Joins("JOIN album_artists ON album_artists.artist_id=artists.id").
 		Preload("ArtistStar", "user_id=?", user.ID).
 		Preload("ArtistRating", "user_id=?", user.ID).
-		Preload("Info").
 		Group("artists.id").
 		Order("artists.name COLLATE NOCASE")
 	if m := getMusicFolder(c.musicPaths, params); m != "" {

--- a/server/ctrlsubsonic/handlers_by_tags.go
+++ b/server/ctrlsubsonic/handlers_by_tags.go
@@ -192,8 +192,9 @@ func (c *Controller) ServeGetAlbumListTwo(r *http.Request) *spec.Response {
 	// TODO: think about removing this extra join to count number
 	// of children. it might make sense to store that in the db
 	q.
-		Select("albums.*, count(tracks.id) child_count, sum(tracks.length) duration").
-		Joins("LEFT JOIN tracks ON tracks.album_id=albums.id").
+		Select(`albums.*,
+			(SELECT count(*) FROM tracks WHERE album_id = albums.id) child_count,
+			(SELECT sum(length) FROM tracks WHERE album_id = albums.id) duration`).
 		Group("albums.id").
 		Joins("JOIN album_artists ON album_artists.album_id=albums.id").
 		Offset(params.GetOrInt("offset", 0)).

--- a/server/ctrlsubsonic/handlers_by_tags.go
+++ b/server/ctrlsubsonic/handlers_by_tags.go
@@ -49,7 +49,7 @@ func (c *Controller) ServeGetArtists(r *http.Request) *spec.Response {
 	// [a-z#] -> 27
 	indexMap := make(map[string]*spec.Index, 27)
 	resp := make([]*spec.Index, 0, 27)
-	for _, artist := range artists {
+	for i, artist := range artists {
 		key := lowerUDecOrHash(artist.IndexName())
 		if _, ok := indexMap[key]; !ok {
 			indexMap[key] = &spec.Index{
@@ -59,9 +59,9 @@ func (c *Controller) ServeGetArtists(r *http.Request) *spec.Response {
 			resp = append(resp, indexMap[key])
 		}
 		if artist.ImageURL != "" {
-			artist.Info = &db.ArtistInfo{ImageURL: artist.ImageURL}
+			artists[i].Info = &db.ArtistInfo{ImageURL: artist.ImageURL}
 		}
-		indexMap[key].Artists = append(indexMap[key].Artists, spec.NewArtistByTags(&artist.Artist))
+		indexMap[key].Artists = append(indexMap[key].Artists, spec.NewArtistByTags(&artists[i].Artist))
 	}
 	sub := spec.NewResponse()
 	sub.Artists = &spec.Artists{

--- a/server/ctrlsubsonic/handlers_internet_radio_test.go
+++ b/server/ctrlsubsonic/handlers_internet_radio_test.go
@@ -86,7 +86,7 @@ func runTestCase(t *testing.T, h handlerSubsonic, q url.Values, admin bool) *spe
 		}
 
 		var jsonUnmarshalTypeError *json.UnmarshalTypeError
-		if errors.As(err, &jsonSyntaxError) {
+		if errors.As(err, &jsonUnmarshalTypeError) {
 			t.Fatalf("invalid type at offset %v\n %s <--", jsonUnmarshalTypeError.Offset, body[0:jsonUnmarshalTypeError.Offset])
 		}
 


### PR DESCRIPTION
The [covering index](https://www.sqlite.org/queryplanner.html#_covering_indexes) also includes length, so that SQLite can avoid reading the rows.

In my experiments with the DB provided by @cascooscuro (see https://github.com/sentriz/gonic/issues/478), adding this index already helps to cut the query time from 2.8s to 1.0s. Replacing the join with subqueries cuts down the time further to 0.3s.

Query plan for the original query:
```
QUERY PLAN
|--SCAN albums
|--SEARCH album_artists USING COVERING INDEX idx_album_artists_album_id (album_id=?)
|--SEARCH tracks USING COVERING INDEX idx_tracks_album_id (album_id=?) LEFT-JOIN
`--USE TEMP B-TREE FOR ORDER BY
```

When using subqueries:
```
QUERY PLAN
|--SCAN albums
|--SEARCH album_artists USING COVERING INDEX idx_album_artists_album_id (album_id=?)
|--CORRELATED SCALAR SUBQUERY 1
|  `--SEARCH tracks USING COVERING INDEX idx_tracks_album_id (album_id=?)
|--CORRELATED SCALAR SUBQUERY 2
|  `--SEARCH tracks USING COVERING INDEX idx_tracks_album_id (album_id=?)
`--USE TEMP B-TREE FOR ORDER BY
```

fixes #478