### PR TITLE
feat: improve cover selection algorithm

### DIFF
--- a/scanner/coverresolve/cover.go
+++ b/scanner/coverresolve/cover.go
@@ -1,0 +1,83 @@
+package coverresolve
+
+import (
+	"regexp"
+	"sort"
+	"strconv"
+	"strings"
+)
+
+var DefaultKeywords = []string{
+	"cover",
+	"folder",
+	"front",
+	"albumart",
+	"album",
+	"artist",
+	"scan",
+}
+
+// Helper function to extract the number from the filename
+func extractNumber(filename string) int {
+	re := regexp.MustCompile(`\d+`)
+	matches := re.FindAllString(filename, -1)
+	if len(matches) == 0 {
+		return 0
+	}
+	num, _ := strconv.Atoi(matches[0])
+	return num
+}
+
+type CoverAlternative struct {
+	Name  string
+	Score int
+}
+
+func SelectCover(covers []string) string {
+	if len(covers) == 0 {
+		return ""
+	}
+
+	coverAlternatives := make([]CoverAlternative, 0)
+
+	for _, keyword := range DefaultKeywords {
+		if len(coverAlternatives) > 0 {
+			break
+		}
+
+		for _, cover := range covers {
+			if strings.Contains(strings.ToLower(cover), keyword) {
+				coverAlternatives = append(coverAlternatives, CoverAlternative{
+					Name:  cover,
+					Score: 0,
+				})
+			}
+		}
+	}
+
+	// parse the integer from the filename
+	// eg. cover(1).jpg will have higher score than cover(114514).jpg
+	for i := range coverAlternatives {
+		coverAlternatives[i].Score -= extractNumber(coverAlternatives[i].Name)
+	}
+
+	// sort by score
+	sort.Slice(coverAlternatives, func(i, j int) bool {
+		return coverAlternatives[i].Score > coverAlternatives[j].Score
+	})
+
+	if len(coverAlternatives) == 0 {
+		return covers[0]
+	}
+
+	return coverAlternatives[0].Name
+}
+
+func IsCover(name string) bool {
+	for _, ext := range []string{"jpg", "jpeg", "png", "bmp", "gif"} {
+		if strings.HasSuffix(strings.ToLower(name), "."+ext) {
+			return true
+		}
+	}
+	return false
+}

--- a/scanner/coverresolve/cover_test.go
+++ b/scanner/coverresolve/cover_test.go
@@ -1,0 +1,85 @@
+package coverresolve
+
+import (
+	"testing"
+)
+
+func TestIsCover(t *testing.T) {
+	tests := []struct {
+		name     string
+		filename string
+		expected bool
+	}{
+		{"JPEG file", "Image.jpg", true},
+		{"JPEG file", "image.jpg", true},
+		{"PNG file", "picture.png", true},
+		{"BMP file", "photo.bmp", true},
+		{"GIF file", "animation.gif", true},
+		{"Non-image file", "document.pdf", false},
+		{"Empty file name", "", false},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			result := IsCover(test.filename)
+			if result != test.expected {
+				t.Errorf("Expected IsCover(%q) to be %v, but got %v", test.filename, test.expected, result)
+			}
+		})
+	}
+}
+
+func TestSelectCover(t *testing.T) {
+
+	tests := []struct {
+		name     string
+		covers   []string
+		expected string
+	}{
+		{
+			name:     "Empty covers slice",
+			covers:   []string{},
+			expected: "",
+		},
+		{
+			name:     "Covers without keywords or numbers case sensitive",
+			covers:   []string{"Cover1.jpg", "cover2.png"},
+			expected: "Cover1.jpg",
+		},
+		{
+			name:     "Covers without keywords or numbers",
+			covers:   []string{"cover1.jpg", "cover2.png"},
+			expected: "cover1.jpg",
+		},
+		{
+			name:     "Covers with keywords and numbers",
+			covers:   []string{"cover12.jpg", "cover2.png", "special_cover1.jpg"},
+			expected: "special_cover1.jpg",
+		},
+		{
+			name:     "Covers with keywords but without numbers",
+			covers:   []string{"cover12.jpg", "cover_keyword.png"},
+			expected: "cover_keyword.png",
+		},
+		{
+			name:     "Covers without keywords but with numbers",
+			covers:   []string{"cover1.jpg", "cover12.png"},
+			expected: "cover1.jpg",
+		},
+		{
+			name:     "Covers with same highest score",
+			covers:   []string{"cover1.jpg", "cover2.jpg", "cover_special.jpg"},
+			expected: "cover_special.jpg",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			// Mock the DefaultScoreRules
+			result := SelectCover(test.covers)
+			if result != test.expected {
+				t.Errorf("Expected SelectCover(%v) to be %q, but got %q", test.covers, test.expected, result)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Hi,

Gonic is a fantastic project for local music streaming. However, I noticed that Gonic doesn't recognize some album covers. After digging into the code, I found that cover art can only be recognized if it follows certain fixed patterns. Most of my albums are downloaded from BitTorrent, so the naming of cover art varies. Here is a sample file list created by running `find /data/ | grep -i -E '.png|.jpg|.jpeg|.webp|.gif '`:

[files.txt](https://github.com/user-attachments/files/15786788/files.txt)

To address this issue, I propose a simple but more effective way to select cover art from an album. Please check the code for details.

A docker images built on this PR is available: `docker.io/heimoshuiyu/gonic:cover`