### PR TITLE
Fix non-admin users not being able to create playlists

### DIFF
--- a/playlist/playlist.go
+++ b/playlist/playlist.go
@@ -94,6 +94,10 @@ func (s *Store) Read(relPath string) (*Playlist, error) {
 		return nil, fmt.Errorf("stat m3u: %w", err)
 	}
 
+	if stat.IsDir() {
+		return nil, errors.New("path is a directory")
+	}
+
 	var playlist Playlist
 	playlist.UpdatedAt = stat.ModTime()
 

--- a/server/ctrlsubsonic/handlers_playlist.go
+++ b/server/ctrlsubsonic/handlers_playlist.go
@@ -75,8 +75,10 @@ func (c *Controller) ServeCreateOrUpdatePlaylist(r *http.Request) *spec.Response
 	playlistPath := playlistIDDecode(playlistID)
 
 	var playlist playlistp.Playlist
-	if pl, _ := c.playlistStore.Read(playlistPath); pl != nil {
-		playlist = *pl
+	if playlistPath != "" {
+		if pl, err := c.playlistStore.Read(playlistPath); err != nil && pl != nil {
+			playlist = *pl
+		}
 	}
 
 	if playlist.UserID != 0 && playlist.UserID != user.ID {


### PR DESCRIPTION
Found this while working on a tentative implementation for #522. It seems that https://github.com/sentriz/gonic/pull/499 introduced some logic that prepopulates `playlist.UserID` to `1` if nothing else can be decoded from the path.

Before this PR, `ServeCreateOrUpdatePlaylist` was trying to figure out if a playlist existed by trying to open the file derived from its name. If the name does not exist, `playlistIDDecode` returns an empty string, which `playlistStore.Read` gladly accepts and proceeds to open `""`, which implies `.`, which does not fail. Then, the code added in #499 will slap the admin user ID on the playlist object, shortly before `playlistStore.Read` realizes this is actually a directory and returns an error.

That error, however, was never checked. As a result, an empty non-existing playlist with `UserID: 1` was returned, and prevented creating playlists as every non-existing playlist will "belong" to admin, and thus no one other than admin could "modify" it.

This PR adds a couple safety checks so this does not happen:
- Does not bother opening a playlist if the decoded path is empty
- Checks error returned by `Open`
- Causes `Open` to fail earlier if a path to a directory is passed