### PR TITLE
Allow sharing playlists across multiple users

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,8 +2,9 @@ FROM alpine:3.19 AS builder-taglib
 WORKDIR /tmp
 COPY alpine/taglib/APKBUILD .
 RUN apk update && \
-    apk add --no-cache abuild && \
-    abuild-keygen -a -n && \
+    apk add --no-cache abuild doas && \
+    echo "permit nopass root" > /etc/doas.conf && \
+    abuild-keygen -a -n -i && \
     REPODEST=/pkgs abuild -F -r
 
 FROM golang:1.21-alpine AS builder

--- a/playlist/playlist.go
+++ b/playlist/playlist.go
@@ -94,6 +94,10 @@ func (s *Store) Read(relPath string) (*Playlist, error) {
 		return nil, fmt.Errorf("stat m3u: %w", err)
 	}
 
+	if stat.IsDir() {
+		return nil, errors.New("path is a directory")
+	}
+
 	var playlist Playlist
 	playlist.UpdatedAt = stat.ModTime()
 

--- a/playlist/playlist.go
+++ b/playlist/playlist.go
@@ -36,6 +36,17 @@ type Playlist struct {
 	IsPublic   bool
 	SharedWith []int
 }
+
+func (p Playlist) CanRead(uid int) bool {
+	return p.IsPublic || p.CanWrite(uid)
+}
+
+func (p Playlist) CanWrite(uid int) bool {
+	return p.UserID == uid || slices.Contains(p.SharedWith, uid)
+}
+
+func (p Playlist) CanDelete(uid int) bool {
+	return p.UserID == uid
 }
 
 type Store struct {

--- a/playlist/playlist_test.go
+++ b/playlist/playlist_test.go
@@ -57,3 +57,70 @@ It has multiple lines 👍
 	require.NoError(t, err)
 	require.True(t, len(playlistIDs) == 1)
 }
+
+func TestAccess(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		name         string
+		playlist     playlist.Playlist
+		userID       int
+		expectRead   bool
+		expectWrite  bool
+		expectDelete bool
+	}{
+		{
+			name: "owner can do anything",
+			playlist: playlist.Playlist{
+				UserID: 7,
+			},
+			userID:       7,
+			expectRead:   true,
+			expectWrite:  true,
+			expectDelete: true,
+		},
+		{
+			name: "third party cannot do anything",
+			playlist: playlist.Playlist{
+				UserID: 7,
+			},
+			userID:       99,
+			expectRead:   false,
+			expectWrite:  false,
+			expectDelete: false,
+		},
+		{
+			name: "third party can read if public",
+			playlist: playlist.Playlist{
+				IsPublic: true,
+				UserID:   7,
+			},
+			userID:       99,
+			expectRead:   true,
+			expectWrite:  false,
+			expectDelete: false,
+		},
+		{
+			name: "shared user can read and write",
+			playlist: playlist.Playlist{
+				IsPublic:   true,
+				UserID:     7,
+				SharedWith: []int{99},
+			},
+			userID:       99,
+			expectRead:   true,
+			expectWrite:  true,
+			expectDelete: false,
+		},
+	} {
+		tc := tc
+
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			require.Equal(t, tc.expectRead, tc.playlist.CanRead(tc.userID))
+			require.Equal(t, tc.expectWrite, tc.playlist.CanWrite(tc.userID))
+			require.Equal(t, tc.expectDelete, tc.playlist.CanDelete(tc.userID))
+		})
+	}
+}

--- a/playlist/playlist_test.go
+++ b/playlist/playlist_test.go
@@ -36,7 +36,8 @@ It has multiple lines 👍
 			"item 2.flac",
 			"item 3.flac",
 		},
-		IsPublic: true,
+		IsPublic:   true,
+		SharedWith: []int{2, 3},
 	}
 
 	newPath := playlist.NewPath(before.UserID, before.Name)
@@ -50,6 +51,7 @@ It has multiple lines 👍
 	require.Equal(t, after.Comment, before.Comment)
 	require.Equal(t, after.Items, before.Items)
 	require.Equal(t, after.IsPublic, before.IsPublic)
+	require.Equal(t, after.SharedWith, before.SharedWith)
 
 	playlistIDs, err = store.List()
 	require.NoError(t, err)

--- a/server/ctrlsubsonic/handlers_playlist.go
+++ b/server/ctrlsubsonic/handlers_playlist.go
@@ -49,13 +49,14 @@ func (c *Controller) ServeGetPlaylists(r *http.Request) *spec.Response {
 }
 
 func (c *Controller) ServeGetPlaylist(r *http.Request) *spec.Response {
+	user := r.Context().Value(CtxUser).(*db.User)
 	params := r.Context().Value(CtxParams).(params.Params)
 	playlistID, err := params.GetFirst("id", "playlistId")
 	if err != nil {
 		return spec.NewError(10, "please provide an `id` parameter")
 	}
 	playlist, err := c.playlistStore.Read(playlistIDDecode(playlistID))
-	if err != nil {
+	if err != nil || !playlist.CanRead(user.ID) {
 		return spec.NewError(70, "playlist with id %s not found", playlistID)
 	}
 	sub := spec.NewResponse()

--- a/server/ctrlsubsonic/handlers_playlist.go
+++ b/server/ctrlsubsonic/handlers_playlist.go
@@ -75,8 +75,10 @@ func (c *Controller) ServeCreateOrUpdatePlaylist(r *http.Request) *spec.Response
 	playlistPath := playlistIDDecode(playlistID)
 
 	var playlist playlistp.Playlist
-	if pl, _ := c.playlistStore.Read(playlistPath); pl != nil {
-		playlist = *pl
+	if playlistPath != "" {
+		if pl, err := c.playlistStore.Read(playlistPath); err != nil && pl != nil {
+			playlist = *pl
+		}
 	}
 
 	if playlist.UserID != 0 && playlist.UserID != user.ID {


### PR DESCRIPTION
This is my take at #522, implementing the easiest functional approach to sharing playlists by specifying a list of users that can edit another user's playlist.

For now, there is no UI for "inviting" users, the m3u file needs to be edited by hand. Users with whom a playlist has been shared can add/remove items from it, but not delete the playlist itself.

Includes commits from #524 