### PR TITLE
fix(dockerfile): install abuild key

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,8 +2,9 @@ FROM alpine:3.19 AS builder-taglib
 WORKDIR /tmp
 COPY alpine/taglib/APKBUILD .
 RUN apk update && \
-    apk add --no-cache abuild && \
-    abuild-keygen -a -n && \
+    apk add --no-cache abuild doas && \
+    echo "permit nopass root" > /etc/doas.conf && \
+    abuild-keygen -a -n -i && \
     REPODEST=/pkgs abuild -F -r
 
 FROM golang:1.21-alpine AS builder


### PR DESCRIPTION
Without this, abuild refuses to run correctly:

```
# Truncated for readability
29.52 (33/33) Purging gmp (6.3.0-r0)
29.52 Executing busybox-1.36.1-r19.trigger
29.52 OK: 17 MiB in 37 packages
29.55 >>> taglib2: Updating the /x86_64 repository index...
29.56 ERROR: libtag-2.0.1-r0.apk: UNTRUSTED signature
29.56 ERROR: libtag_c-2.0.1-r0.apk: UNTRUSTED signature
29.56 ERROR: taglib2-2.0.1-r0.apk: UNTRUSTED signature
29.56 ERROR: taglib2-dev-2.0.1-r0.apk: UNTRUSTED signature
29.56 >>> ERROR: taglib2: Failed to create index
29.56 >>> taglib2: Uninstalling dependencies...
29.73 ERROR: No such package: .makedepends-taglib2
------

 8 warnings found (use --debug to expand):
 - LegacyKeyValueFormat: "LABEL key=value" should be used instead of legacy "LABEL key value" format (line 30)
 - LegacyKeyValueFormat: "ENV key=value" should be used instead of legacy "ENV key value" format (line 49)
 - LegacyKeyValueFormat: "ENV key=value" should be used instead of legacy "ENV key value" format (line 50)
 - LegacyKeyValueFormat: "ENV key=value" should be used instead of legacy "ENV key value" format (line 51)
 - LegacyKeyValueFormat: "ENV key=value" should be used instead of legacy "ENV key value" format (line 52)
 - LegacyKeyValueFormat: "ENV key=value" should be used instead of legacy "ENV key value" format (line 53)
 - LegacyKeyValueFormat: "ENV key=value" should be used instead of legacy "ENV key value" format (line 54)
 - LegacyKeyValueFormat: "ENV key=value" should be used instead of legacy "ENV key value" format (line 55)
Dockerfile:4
--------------------
   3 |     COPY alpine/taglib/APKBUILD .
   4 | >>> RUN apk update && \
   5 | >>>     apk add --no-cache abuild && \
   6 | >>>     abuild-keygen -a -n && \
   7 | >>>     REPODEST=/pkgs abuild -F -r
   8 |
--------------------
ERROR: failed to solve: process "/bin/sh -c apk update &&     apk add --no-cache abuild &&     abuild-keygen -a -n &&     REPODEST=/pkgs abuild -F -r" did not complete successfully: exit code: 1
```

I'm not extremely familiar with alpine, so no idea why this happens. But installing the generated key seems to fix it. Installing the key required doas, which required a config file, so that's pretty much what I did.