### PR TITLE
Use file name / foder name for unknown tag retrieval.

### DIFF
--- a/mockfs/mockfs.go
+++ b/mockfs/mockfs.go
@@ -371,6 +371,8 @@ func (i *TagInfo) ReplayGainAlbumPeak() float32 { return 0 }
 func (i *TagInfo) Length() int  { return firstInt(100, i.RawLength) }
 func (i *TagInfo) Bitrate() int { return firstInt(100, i.RawBitrate) }
 
+func (i *TagInfo) AbsPath() string { return "" }
+
 var _ tagcommon.Reader = (*tagReader)(nil)
 
 func firstInt(or int, ints ...int) int {

--- a/scanner/scanner.go
+++ b/scanner/scanner.go
@@ -463,8 +463,9 @@ func populateTrack(tx *db.DB, album *db.Album, track *db.Track, trags tagcommon.
 	track.Size = size
 	track.AlbumID = album.ID
 
-	track.TagTitle = trags.Title()
-	track.TagTitleUDec = decoded(trags.Title())
+	tagTitle := tagcommon.MustTitle(trags)
+	track.TagTitle = tagTitle
+	track.TagTitleUDec = decoded(tagTitle)
 	track.TagTrackArtist = tagcommon.MustArtist(trags)
 	track.TagTrackNumber = trags.TrackNumber()
 	track.TagDiscNumber = trags.DiscNumber()

--- a/tags/tagcommon/tagcommmon.go
+++ b/tags/tagcommon/tagcommmon.go
@@ -2,6 +2,7 @@ package tagcommon
 
 import (
 	"errors"
+	"path"
 )
 
 var ErrUnsupported = errors.New("filetype unsupported")
@@ -33,19 +34,31 @@ type Info interface {
 
 	Length() int
 	Bitrate() int
+
+	AbsPath() string
 }
 
 const (
-	FallbackAlbum  = "Unknown Album"
 	FallbackArtist = "Unknown Artist"
 	FallbackGenre  = "Unknown Genre"
 )
+
+func MustTitle(p Info) string {
+	if r := p.Title(); r != "" {
+		return r
+	}
+
+	// return the file name for title name
+	return path.Base(p.AbsPath())
+}
 
 func MustAlbum(p Info) string {
 	if r := p.Album(); r != "" {
 		return r
 	}
-	return FallbackAlbum
+
+	// return the dir name for album name
+	return path.Base(path.Dir(p.AbsPath()))
 }
 
 func MustArtist(p Info) string {

--- a/tags/taglib/taglib.go
+++ b/tags/taglib/taglib.go
@@ -28,12 +28,13 @@ func (TagLib) Read(absPath string) (tagcommon.Info, error) {
 	defer f.Close()
 	props := f.ReadAudioProperties()
 	raw := f.ReadTags()
-	return &info{raw, props}, nil
+	return &info{raw, props, absPath}, nil
 }
 
 type info struct {
-	raw   map[string][]string
-	props *audiotags.AudioProperties
+	raw     map[string][]string
+	props   *audiotags.AudioProperties
+	abspath string
 }
 
 // https://picard-docs.musicbrainz.org/downloads/MusicBrainz_Picard_Tag_Map.html
@@ -59,6 +60,8 @@ func (i *info) ReplayGainAlbumPeak() float32 { return flt(first(find(i.raw, "rep
 
 func (i *info) Length() int  { return i.props.Length }
 func (i *info) Bitrate() int { return i.props.Bitrate }
+
+func (i *info) AbsPath() string { return i.abspath }
 
 func first[T comparable](is []T) T {
 	var z T


### PR DESCRIPTION
When taglib cannot retrieve the title of the media or the title of the album, use the filename as the track name and the folder name as the album name.

I have a lot of music downloaded from YouTube, which doesn't have recognizable media metadata. After scanning with gonic, all of them turn into empty titles and unknown albums, making it difficult for me to distinguish the music. For example, like this:

![Screenshot_20240925_150357](https://github.com/user-attachments/assets/7742c760-6e96-4dd4-b109-d1ac9b1004d5)

These pieces of music without metadata should be manually managed by the user using filenames and folders. In this way, using the filename and folder as the title and album name is reasonable. For example, like this: (the file is named `aino.opus` under folder `miku`)

![Screenshot_20240925_150148](https://github.com/user-attachments/assets/69bd9536-2074-424f-bf97-10e090edb52e)