### PR TITLE
feat: support embedded album art covers

### DIFF
--- a/cmd/gonic/gonic.go
+++ b/cmd/gonic/gonic.go
@@ -199,6 +199,7 @@ func main() {
 		},
 		tagReader,
 		*confExcludePattern,
+		cacheDirCovers,
 	)
 	podcast := podcast.New(dbc, *confPodcastPath, tagReader)
 	transcoder := transcode.NewCachingTranscoder(

--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,8 @@ module go.senan.xyz/gonic
 
 go 1.23.0
 
+replace github.com/sentriz/audiotags => github.com/turtletowerz/audiotags v1.0.0
+
 require (
 	github.com/Masterminds/sprig v2.22.0+incompatible
 	github.com/andybalholm/cascadia v1.3.2

--- a/go.sum
+++ b/go.sum
@@ -128,8 +128,6 @@ github.com/rivo/uniseg v0.4.7 h1:WUdvkW8uEhrYfLC4ZzdpI2ztxP1I582+49Oc5Mq64VQ=
 github.com/rivo/uniseg v0.4.7/go.mod h1:FN3SvrM+Zdj16jyLfmOkMNblXMcoc8DfTHruCPUcx88=
 github.com/rogpeppe/go-internal v1.12.0 h1:exVL4IDcn6na9z1rAb56Vxr+CgyK3nn3O+epU5NdKM8=
 github.com/rogpeppe/go-internal v1.12.0/go.mod h1:E+RYuTGaKKdloAfM02xzb0FW3Paa99yedzYV+kq4uf4=
-github.com/sentriz/audiotags v0.0.0-20240918190302-048d6470aae6 h1:WCZxu77OR9yzKGZugQC1dHhslXROOJT+UL5JCtJbBq8=
-github.com/sentriz/audiotags v0.0.0-20240918190302-048d6470aae6/go.mod h1:+pmkMFDEXJuu/u4h2OYJVfYF2qIhXJD7kqvWq6q5Zo0=
 github.com/sentriz/gormstore v0.0.0-20220105134332-64e31f7f6981 h1:sLILANWN76ja66/K4k/mBqJuCjDZaM67w+Ru6rEB0s0=
 github.com/sentriz/gormstore v0.0.0-20220105134332-64e31f7f6981/go.mod h1:Rx8XB1ck+so+41uu9VY1gMKs1CPQ2NTq0pzf+OCCQHo=
 github.com/ssor/bom v0.0.0-20170718123548-6386211fdfcf h1:pvbZ0lM0XWPBqUKqFU8cmavspvIl9nulOYwdy6IFRRo=
@@ -138,6 +136,8 @@ github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/stretchr/testify v1.9.0 h1:HtqpIVDClZ4nwg75+f6Lvsy/wHu+3BoSGCbBAcpTsTg=
 github.com/stretchr/testify v1.9.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
+github.com/turtletowerz/audiotags v1.0.0 h1:jgycmmi3c4FmkfrkX6zoU+8eyat/3Qw8GFanWDf9pZQ=
+github.com/turtletowerz/audiotags v1.0.0/go.mod h1:+pmkMFDEXJuu/u4h2OYJVfYF2qIhXJD7kqvWq6q5Zo0=
 github.com/yuin/goldmark v1.4.13/go.mod h1:6yULJ656Px+3vBD8DxQVa3kxgyrAnzto9xy5taEt/CY=
 go.senan.xyz/flagconf v0.1.9 h1:LBDmqiVFgijfqFXDzH97gPn0qDbg1Dq6/vxsxS/TzC4=
 go.senan.xyz/flagconf v0.1.9/go.mod h1:NqOFfSwJvNWXOTUabcRZ8mPK9+sJmhStJhqtEt74wNQ=

--- a/mockfs/mockfs.go
+++ b/mockfs/mockfs.go
@@ -68,7 +68,7 @@ func newMockFS(tb testing.TB, dirs []string, excludePattern string) *MockFS {
 	}
 
 	tagReader := &tagReader{paths: map[string]*TagInfo{}}
-	scanner := scanner.New(absDirs, dbc, multiValueSettings, tagReader, excludePattern)
+	scanner := scanner.New(absDirs, dbc, multiValueSettings, tagReader, excludePattern, "")
 
 	return &MockFS{
 		t:         tb,

--- a/server/ctrlsubsonic/spec/construct_by_folder.go
+++ b/server/ctrlsubsonic/spec/construct_by_folder.go
@@ -19,15 +19,13 @@ func NewAlbumByFolder(f *db.Album) *Album {
 		Duration:      f.Duration,
 		Created:       f.CreatedAt,
 		AverageRating: formatRating(f.AverageRating),
+		CoverID:       f.SID(),
 	}
 	if f.AlbumStar != nil {
 		a.Starred = &f.AlbumStar.StarDate
 	}
 	if f.AlbumRating != nil {
 		a.UserRating = f.AlbumRating.Rating
-	}
-	if f.Cover != "" {
-		a.CoverID = f.SID()
 	}
 	return a
 }
@@ -40,15 +38,13 @@ func NewTCAlbumByFolder(f *db.Album) *TrackChild {
 		ParentID:      f.ParentSID(),
 		CreatedAt:     f.CreatedAt,
 		AverageRating: formatRating(f.AverageRating),
+		CoverID:       f.SID(),
 	}
 	if f.AlbumStar != nil {
 		trCh.Starred = &f.AlbumStar.StarDate
 	}
 	if f.AlbumRating != nil {
 		trCh.UserRating = f.AlbumRating.Rating
-	}
-	if f.Cover != "" {
-		trCh.CoverID = f.SID()
 	}
 	return trCh
 }
@@ -77,12 +73,10 @@ func NewTCTrackByFolder(t *db.Track, parent *db.Album) *TrackChild {
 		MusicBrainzID: t.TagBrainzID,
 		CreatedAt:     t.CreatedAt,
 		AverageRating: formatRating(t.AverageRating),
+		CoverID:       parent.SID(),
 	}
 	if trCh.Title == "" {
 		trCh.Title = t.Filename
-	}
-	if parent.Cover != "" {
-		trCh.CoverID = parent.SID()
 	}
 	if t.Album != nil {
 		trCh.Album = t.Album.RightPath

--- a/server/ctrlsubsonic/spec/construct_by_tags.go
+++ b/server/ctrlsubsonic/spec/construct_by_tags.go
@@ -22,9 +22,7 @@ func NewAlbumByTags(a *db.Album, artists []*db.Artist) *Album {
 		Year:          a.TagYear,
 		Tracks:        []*TrackChild{},
 		AverageRating: formatRating(a.AverageRating),
-	}
-	if a.Cover != "" {
-		ret.CoverID = a.SID()
+		CoverID:       a.SID(),
 	}
 	if a.AlbumStar != nil {
 		ret.Starred = &a.AlbumStar.StarDate
@@ -84,9 +82,7 @@ func NewTrackByTags(t *db.Track, album *db.Album) *TrackChild {
 		Year:               album.TagYear,
 		AverageRating:      formatRating(t.AverageRating),
 		TranscodeMeta:      TranscodeMeta{},
-	}
-	if album.Cover != "" {
-		ret.CoverID = album.SID()
+		CoverID:            album.SID(),
 	}
 	if t.TrackStar != nil {
 		ret.Starred = &t.TrackStar.StarDate


### PR DESCRIPTION
This adds complete support for embedded album art for any format that TagLib supports.

I'm marking this as a draft because there are a few code considerations I would like to get input on before continuing:
1. The relevant `audiotags` package changes need to be made to `sentriz/audiotags` instead of linking to my personal repo. I did this for testing reasons but it will be removed before this is actually committed
2. The way the cover cache path is passed around feels janky, and im wondering if there should be a more intentional settings or shared variables package.
3. All of the embedded logic is shoved into `tagcommon`; not sure if this is appropriate or not