### PR TITLE
Making HTTP User Agent a runtime option

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,7 @@ password can then be changed from the web interface
 | `GONIC_TRANSCODE_CACHE_SIZE` | `-transcode-cache-size` | **optional** size of the transcode cache in MB (0 = no limit) |
 | `GONIC_TRANSCODE_EJECT_INTERVAL` | `-transcode-eject-interval` | **optional** interval (in minutes) to eject transcode cache (0 = never) |
 | `GONIC_EXPVAR`                   | `-expvar`                   | **optional** enable the /debug/vars endpoint (exposes useful debugging attributes as well as database stats)                                                                                                                                                                      |
+| `GONIC_HTTP_USER_AGENT`          | `-http-user-agent`          | **optional** sets the HTTP user agent used to fetch podcasts     |
 
 ## multi valued tags (v0.16+)
 

--- a/cmd/gonic/gonic.go
+++ b/cmd/gonic/gonic.go
@@ -59,6 +59,8 @@ func main() {
 	confPodcastPurgeAgeDays := flag.Uint("podcast-purge-age", 0, "age (in days) to purge podcast episodes if not accessed (optional)")
 	confPodcastPath := flag.String("podcast-path", "", "path to podcasts")
 
+	confHTTPUserAgent := flag.String("http-user-agent", "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36", "user agent to fetch podcasts (optional)")
+
 	confCachePath := flag.String("cache-path", "", "path to cache")
 
 	var confMusicPaths pathAliases
@@ -200,7 +202,7 @@ func main() {
 		tagReader,
 		*confExcludePattern,
 	)
-	podcast := podcast.New(dbc, *confPodcastPath, tagReader)
+	podcast := podcast.New(dbc, *confPodcastPath, tagReader, *confHTTPUserAgent)
 	transcoder := transcode.NewCachingTranscoder(
 		transcode.NewFFmpegTranscoder(),
 		cacheDirAudio,

--- a/podcast/podcast.go
+++ b/podcast/podcast.go
@@ -25,22 +25,20 @@ import (
 
 var ErrNoAudioInFeedItem = errors.New("no audio in feed item")
 
-const (
-	fetchUserAgent = `Mozilla/5.0 (Macintosh; Intel Mac OS X 10_7_5) AppleWebKit/537.11 (KHTML, like Gecko) Chrome/23.0.1271.64 Safari/537.11`
-)
-
 type Podcasts struct {
 	httpClient *http.Client
 	db         *db.DB
 	baseDir    string
 	tagReader  tagcommon.Reader
+	userAgent  string
 }
 
-func New(db *db.DB, base string, tagReader tagcommon.Reader) *Podcasts {
+func New(db *db.DB, base string, tagReader tagcommon.Reader, userAgent string) *Podcasts {
 	return &Podcasts{
 		db:         db,
 		baseDir:    base,
 		tagReader:  tagReader,
+		userAgent:  userAgent,
 		httpClient: &http.Client{},
 	}
 }
@@ -331,7 +329,7 @@ func (p *Podcasts) downloadPodcastCover(podcast *db.Podcast) error {
 	if err != nil {
 		return fmt.Errorf("create http request: %w", err)
 	}
-	req.Header.Add("User-Agent", fetchUserAgent)
+	req.Header.Add("User-Agent", p.userAgent)
 
 	resp, err := p.httpClient.Do(req)
 	if err != nil {
@@ -475,7 +473,7 @@ func (p *Podcasts) doPodcastDownload(podcast *db.Podcast, podcastEpisode *db.Pod
 	if err != nil {
 		return fmt.Errorf("create http request: %w", err)
 	}
-	req.Header.Add("User-Agent", fetchUserAgent)
+	req.Header.Add("User-Agent", p.userAgent)
 
 	resp, err := p.httpClient.Do(req)
 	if err != nil {

--- a/podcast/podcast_test.go
+++ b/podcast/podcast_test.go
@@ -24,7 +24,7 @@ func TestPodcastsAndEpisodesWithSameName(t *testing.T) {
 	m := mockfs.New(t)
 
 	base := t.TempDir()
-	podcasts := New(m.DB(), base, m.TagReader())
+	podcasts := New(m.DB(), base, m.TagReader(), "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36")
 
 	fp := gofeed.NewParser()
 	newFeed, err := fp.Parse(bytes.NewReader(testRSS))


### PR DESCRIPTION
I've had issues with some podcast feeds with Akamai CDN not liking the built-in hardcoded HTTP user agent, and blocking based on it. 

This PR adds a new runtime option to change the HTTP User Agent on demand if needed.