### PR TITLE
Fix transcoding typos

### DIFF
--- a/server/ctrlsubsonic/handlers_raw.go
+++ b/server/ctrlsubsonic/handlers_raw.go
@@ -194,7 +194,7 @@ func (c *Controller) ServeStream(w http.ResponseWriter, r *http.Request) *spec.R
 	}
 
 	client, _ := params.Get("c")
-	pref, err := streamGetTransodePreference(c.dbc, user.ID, client)
+	pref, err := streamGetTranscodePreference(c.dbc, user.ID, client)
 	if err != nil && !errors.Is(err, gorm.ErrRecordNotFound) {
 		return spec.NewError(0, "couldn't find transcode preference: %v", err)
 	}
@@ -224,7 +224,7 @@ func (c *Controller) ServeStream(w http.ResponseWriter, r *http.Request) *spec.R
 		profile = transcode.WithSeek(profile, time.Second*time.Duration(timeOffset))
 	}
 
-	log.Printf("trancoding to %q with at bitrate %d", profile.MIME(), profile.BitRate())
+	log.Printf("transcoding to %q with at bitrate %d", profile.MIME(), profile.BitRate())
 
 	w.Header().Set("Content-Type", profile.MIME())
 	if err := c.transcoder.Transcode(r.Context(), profile, file.AbsPath(), w); err != nil && !errors.Is(err, transcode.ErrFFmpegKilled) {
@@ -252,7 +252,7 @@ func (c *Controller) ServeGetAvatar(w http.ResponseWriter, r *http.Request) *spe
 	return nil
 }
 
-func streamGetTransodePreference(dbc *db.DB, userID int, client string) (*db.TranscodePreference, error) {
+func streamGetTranscodePreference(dbc *db.DB, userID int, client string) (*db.TranscodePreference, error) {
 	var pref db.TranscodePreference
 	err := dbc.
 		Where("user_id=?", userID).
@@ -270,7 +270,7 @@ func streamGetTransodePreference(dbc *db.DB, userID int, client string) (*db.Tra
 }
 
 func streamGetTranscodeMeta(dbc *db.DB, userID int, client string) spec.TranscodeMeta {
-	pref, _ := streamGetTransodePreference(dbc, userID, client)
+	pref, _ := streamGetTranscodePreference(dbc, userID, client)
 	if pref == nil {
 		return spec.TranscodeMeta{}
 	}


### PR DESCRIPTION
This fixes a typo on a log message, and another on a function name.


Heads up for the log message: although I think it's better to have it correctly, it would impact anyone using this downstream.
For example, I found this while creating a filter on grafana to see how often transcodings were happening. For anyone who has already setup, either something similar or anything that relies on that log message, they'll have to update their configuration.

I don't know if that's even happening, since maybe that would have resulted on this same change before, but wanted to make sure we are aware of that.