### PR TITLE
Use podcast author if episode author is not defined.

### DIFF
--- a/db/db.go
+++ b/db/db.go
@@ -475,6 +475,7 @@ type Podcast struct {
 	Episodes     []*PodcastEpisode
 	AutoDownload PodcastAutoDownload
 	RootDir      string
+	Author       string
 }
 
 func (p *Podcast) SID() *specid.ID {

--- a/db/migrations.go
+++ b/db/migrations.go
@@ -76,6 +76,7 @@ func (db *DB) Migrate(ctx MigrationContext) error {
 		construct(ctx, "202501152035", migrateTrackAddIndexOnAlbumID),
 		construct(ctx, "202501152036", migrateAlbumAddIndexOnParentID),
 		construct(ctx, "202502012036", migratePodcastEpisode),
+		construct(ctx, "2025040132036", migratePodcast),
 	}
 
 	return gormigrate.

--- a/db/migrations.go
+++ b/db/migrations.go
@@ -76,7 +76,7 @@ func (db *DB) Migrate(ctx MigrationContext) error {
 		construct(ctx, "202501152035", migrateTrackAddIndexOnAlbumID),
 		construct(ctx, "202501152036", migrateAlbumAddIndexOnParentID),
 		construct(ctx, "202502012036", migratePodcastEpisode),
-		construct(ctx, "2025040132036", migratePodcast),
+		construct(ctx, "202504132036", migratePodcast),
 	}
 
 	return gormigrate.

--- a/podcast/podcast.go
+++ b/podcast/podcast.go
@@ -1,6 +1,7 @@
 package podcast
 
 import (
+	"cmp"
 	"errors"
 	"fmt"
 	"io"
@@ -224,14 +225,6 @@ func (p *Podcasts) isAudio(rawItemURL string) (bool, error) {
 	return p.tagReader.CanRead(itemURL.Path), nil
 }
 
-func getPodcastEpisodeAuthor(episodeAuthor string, podcastAuthor string) string {
-	if len(episodeAuthor) > 0 {
-		return episodeAuthor
-	}
-
-	return podcastAuthor
-}
-
 func itemToEpisode(podcast *db.Podcast, size, duration int, audio string, item *gofeed.Item) *db.PodcastEpisode {
 	return &db.PodcastEpisode{
 		PodcastID:   podcast.ID,
@@ -242,7 +235,7 @@ func itemToEpisode(podcast *db.Podcast, size, duration int, audio string, item *
 		PublishDate: item.PublishedParsed,
 		AudioURL:    audio,
 		Status:      db.PodcastEpisodeStatusSkipped,
-		Artist:      getPodcastEpisodeAuthor(item.ITunesExt.Author, podcast.Author),
+		Artist:      cmp.Or(item.ITunesExt.Author, podcast.Author),
 		Album:       podcast.Title,
 	}
 }


### PR DESCRIPTION
This will use the podcast author if the podcast episode author is `undefined`. Should fix the issue stated in https://github.com/sentriz/gonic/issues/565.