### PR TITLE
Skip bookmarks for missing items instead of failing

### DIFF
--- a/server/ctrlsubsonic/handlers_bookmark.go
+++ b/server/ctrlsubsonic/handlers_bookmark.go
@@ -45,7 +45,12 @@ func (c *Controller) ServeGetBookmarks(r *http.Request) *spec.Response {
 				Find(&track, "id=?", bookmark.EntryID).
 				Error
 			if err != nil {
-				return spec.NewError(10, "finding entry: %v", err)
+				/*
+				 * We get here if we have a bookmark for a Track that no longer exists, this should be an
+				 * error because tracks can disappear if the files are moved etc. Just skip the not found
+				 * entry and move on.
+				 */
+				continue
 			}
 			respBookmark.Entry = spec.NewTrackByTags(&track, track.Album)
 		case specid.PodcastEpisode:
@@ -55,7 +60,8 @@ func (c *Controller) ServeGetBookmarks(r *http.Request) *spec.Response {
 				Find(&podcastEpisode, "id=?", bookmark.EntryID).
 				Error
 			if err != nil {
-				return spec.NewError(10, "finding entry: %v", err)
+				/* Same as with the missing track above. */
+				continue
 			}
 			respBookmark.Entry = spec.NewTCPodcastEpisode(&podcastEpisode)
 		default:


### PR DESCRIPTION
Currently if a bookmark exists for an item that does not exist in the db, either because it has been removed or it never did, the user is prevented from retrieving any bookmarks. We can be in this state if media has moved or been deleted, but also because the createBookmark endpoint does not verify the item id provided.

This patch makes the getBookmarks endpoint ignore bookmarks for missingitems.

Fixes: https://github.com/sentriz/gonic/issues/578