### PR TITLE
Folder name as Album [Fixes #611 and #89]

### DIFF
--- a/scanner/scanner.go
+++ b/scanner/scanner.go
@@ -490,9 +490,8 @@ func populateAlbumEmbeddedCover(tx *db.DB, album *db.Album, track *db.Track, trp
 }
 
 func populateAlbum(tx *db.DB, album *db.Album, trags map[string][]string, modTime, createTime time.Time) error {
-	albumName := tags.MustAlbum(trags)
-	album.TagTitle = albumName
-	album.TagTitleUDec = decoded(albumName)
+	album.TagTitle = album.RightPath
+	album.TagTitleUDec = decoded(album.RightPath)
 	album.TagAlbumArtist = tags.MustAlbumArtist(trags)
 	album.TagBrainzID = normtag.Get(trags, normtag.MusicBrainzReleaseID)
 	album.TagYear = tags.MustYear(trags)


### PR DESCRIPTION
This small change, makes the Folder name as the album name. 

But for users like me, where most songs in a folder may not have the same album, this is a blessing.
Also, for Various Artists folders, this should be great.
I understand that this will mean, if one folder contains one album, the folder name should match the album name.

Fixes #611 and #89, maybe more