### PR TITLE
Implement Subsonic getNowPlaying API endpoint

### DIFF
--- a/server/ctrlsubsonic/ctrl.go
+++ b/server/ctrlsubsonic/ctrl.go
@@ -134,6 +134,7 @@ func New(dbc *db.DB, scannr *scanner.Scanner, musicPaths []MusicPath, podcastsPa
 	c.Handle("/getSimilarSongs2", chain(resp(c.ServeGetSimilarSongsTwo)))
 	c.Handle("/getLyrics", chain(resp(c.ServeGetLyrics)))
 	c.Handle("/getLyricsBySongId", chain(resp(c.ServeGetLyricsBySongID)))
+	c.Handle("/getNowPlaying", chain(resp(c.ServeGetNowPlaying)))
 
 	// raw
 	c.Handle("/getCoverArt", chainRaw(respRaw(c.ServeGetCoverArt)))

--- a/server/ctrlsubsonic/handlers_common.go
+++ b/server/ctrlsubsonic/handlers_common.go
@@ -800,14 +800,14 @@ func (c *Controller) ServeGetNowPlaying(r *http.Request) *spec.Response {
 	for _, rec := range records {
 		minutesAgo := int(time.Since(rec.Time).Minutes())
 		entry := &spec.NowPlayingEntry{
-			Id:         rec.TrackID,
+			ID:         rec.TrackID,
 			Title:      rec.Title,
 			IsDir:      rec.IsDir,
 			Album:      rec.Album,
 			Artist:     rec.Artist,
 			Username:   rec.Username,
 			MinutesAgo: minutesAgo,
-			PlayerId:   rec.PlayerID,
+			PlayerID:   rec.PlayerID,
 		}
 		sub.NowPlaying.List = append(sub.NowPlaying.List, entry)
 	}

--- a/server/ctrlsubsonic/handlers_common.go
+++ b/server/ctrlsubsonic/handlers_common.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"path/filepath"
 	"slices"
+	"sort"
 	"strings"
 	"sync"
 	"time"
@@ -786,4 +787,30 @@ func lowerUDecOrHash(in string) string {
 		return "#"
 	}
 	return string(lower)
+}
+
+func (c *Controller) ServeGetNowPlaying(r *http.Request) *spec.Response {
+	sub := spec.NewResponse()
+	sub.NowPlaying = &spec.NowPlaying{}
+
+	records := c.nowPlayingCache.GetRecent(60 * time.Minute)
+	// sort newest first
+	sort.Slice(records, func(i, j int) bool { return records[i].Time.After(records[j].Time) })
+
+	for _, rec := range records {
+		minutesAgo := int(time.Since(rec.Time).Minutes())
+		entry := &spec.NowPlayingEntry{
+			Id:         rec.TrackID,
+			Title:      rec.Title,
+			IsDir:      rec.IsDir,
+			Album:      rec.Album,
+			Artist:     rec.Artist,
+			Username:   rec.Username,
+			MinutesAgo: minutesAgo,
+			PlayerId:   rec.PlayerID,
+		}
+		sub.NowPlaying.List = append(sub.NowPlaying.List, entry)
+	}
+
+	return sub
 }

--- a/server/ctrlsubsonic/handlers_common.go
+++ b/server/ctrlsubsonic/handlers_common.go
@@ -804,37 +804,45 @@ func lowerUDecOrHash(in string) string {
 }
 
 func (c *Controller) ServeGetNowPlaying(r *http.Request) *spec.Response {
+	params := r.Context().Value(CtxParams).(params.Params)
+	user := r.Context().Value(CtxUser).(*db.User)
+
+	var plays []*db.TrackPlay
+	err := c.dbc.
+		Preload("User").
+		Where("id IN (SELECT max(id) FROM track_plays GROUP BY user_id)").
+		Where("time > ?", time.Now().Add(-time.Hour)).
+		Order("time DESC").
+		Find(&plays).
+		Error
+	if err != nil {
+		return spec.NewError(0, "find track plays: %v", err)
+	}
+
+	client := params.GetOr("c", "")
+	transcodeMeta := streamGetTranscodeMeta(c.dbc, user.ID, client)
+
 	sub := spec.NewResponse()
-	sub.NowPlaying = &spec.NowPlaying{}
-
-	type NowPlayingRecord struct {
-		Username    string
-		MinutesAgo  int
-		UserID      int
-		TrackPlayID int
-		Title       string
-		IsDir       bool
-		Album       string
-		Artist      string
-	}
-
-	var records []NowPlayingRecord
-	// use track_plays.user_id as PlayerID, and track_plays.id as ID; limit to entries within the last 60 minutes
-	c.dbc.Raw("SELECT u.name AS username, CAST(round((julianday(CURRENT_TIMESTAMP) - julianday(time)) * 1440) AS INTEGER) AS minutes_ago, tp.user_id AS player_id, tp.id AS id, t.tag_title AS title, FALSE AS is_dir, a.tag_title AS album, t.tag_track_artist AS artist FROM track_plays tp NATURAL JOIN (SELECT max(id) AS id, user_id FROM track_plays GROUP BY user_id) JOIN users u ON tp.user_id = u.id JOIN tracks t ON tp.track_id = t.id JOIN albums a ON t.album_id = a.id WHERE minutes_ago <= 60").Scan(&records)
-
-	for _, rec := range records {
-		entry := &spec.NowPlayingEntry{
-			ID:         rec.TrackPlayID,
-			Title:      rec.Title,
-			IsDir:      rec.IsDir,
-			Album:      rec.Album,
-			Artist:     rec.Artist,
-			Username:   rec.Username,
-			MinutesAgo: rec.MinutesAgo,
-			PlayerID:   rec.UserID,
+	sub.NowPlaying = &spec.NowPlaying{List: []*spec.NowPlayingEntry{}}
+	for _, play := range plays {
+		var track spec.TrackRow
+		err := c.dbc.DB.
+			Scopes(spec.LoadTrackByTags(user.ID)).
+			First(&track, play.TrackID).
+			Error
+		if err != nil {
+			return spec.NewError(0, "find track: %v", err)
 		}
-		sub.NowPlaying.List = append(sub.NowPlaying.List, entry)
-	}
 
+		child := spec.NewTrackByTags(client, &track, track.Album)
+		child.TranscodeMeta = transcodeMeta
+
+		sub.NowPlaying.List = append(sub.NowPlaying.List, &spec.NowPlayingEntry{
+			TrackChild: *child,
+			Username:   play.User.Name,
+			MinutesAgo: int(time.Since(play.Time).Minutes()),
+			PlayerID:   play.UserID,
+		})
+	}
 	return sub
 }

--- a/server/ctrlsubsonic/handlers_common.go
+++ b/server/ctrlsubsonic/handlers_common.go
@@ -802,3 +802,39 @@ func lowerUDecOrHash(in string) string {
 	}
 	return string(lower)
 }
+
+func (c *Controller) ServeGetNowPlaying(r *http.Request) *spec.Response {
+	sub := spec.NewResponse()
+	sub.NowPlaying = &spec.NowPlaying{}
+
+	type NowPlayingRecord struct {
+		Username    string
+		MinutesAgo  int
+		UserID      int
+		TrackPlayID int
+		Title       string
+		IsDir       bool
+		Album       string
+		Artist      string
+	}
+
+	var records []NowPlayingRecord
+	// use track_plays.user_id as PlayerID, and track_plays.id as ID; limit to entries within the last 60 minutes
+	c.dbc.Raw("SELECT u.name AS username, CAST(round((julianday(CURRENT_TIMESTAMP) - julianday(time)) * 1440) AS INTEGER) AS minutes_ago, tp.user_id AS player_id, tp.id AS id, t.tag_title AS title, FALSE AS is_dir, a.tag_title AS album, t.tag_track_artist AS artist FROM track_plays tp NATURAL JOIN (SELECT max(id) AS id, user_id FROM track_plays GROUP BY user_id) JOIN users u ON tp.user_id = u.id JOIN tracks t ON tp.track_id = t.id JOIN albums a ON t.album_id = a.id WHERE minutes_ago <= 60").Scan(&records)
+
+	for _, rec := range records {
+		entry := &spec.NowPlayingEntry{
+			ID:         rec.TrackPlayID,
+			Title:      rec.Title,
+			IsDir:      rec.IsDir,
+			Album:      rec.Album,
+			Artist:     rec.Artist,
+			Username:   rec.Username,
+			MinutesAgo: rec.MinutesAgo,
+			PlayerID:   rec.UserID,
+		}
+		sub.NowPlaying.List = append(sub.NowPlaying.List, entry)
+	}
+
+	return sub
+}

--- a/server/ctrlsubsonic/handlers_common_test.go
+++ b/server/ctrlsubsonic/handlers_common_test.go
@@ -1,0 +1,61 @@
+package ctrlsubsonic
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestServeGetNowPlaying_FromCache(t *testing.T) {
+	t.Parallel()
+
+	now := time.Now().UTC()
+
+	c := Controller{
+		nowPlayingCache: NewNowPlayingCache(),
+	}
+
+	c.nowPlayingCache.Set(1, NowPlayingRecord{
+		TrackID:  101,
+		Title:    "Track One",
+		IsDir:    false,
+		Album:    "Album One",
+		Artist:   "Artist One",
+		Username: "alice",
+		Time:     now.Add(-2 * time.Minute),
+		PlayerID: 11,
+	})
+
+	c.nowPlayingCache.Set(2, NowPlayingRecord{
+		TrackID:  202,
+		Title:    "Track Two",
+		IsDir:    false,
+		Album:    "Album Two",
+		Artist:   "Artist Two",
+		Username: "bob",
+		Time:     now.Add(-30 * time.Minute),
+		PlayerID: 22,
+	})
+
+	resp := c.ServeGetNowPlaying(nil)
+	require.NotNil(t, resp)
+	require.NotNil(t, resp.NowPlaying)
+	list := resp.NowPlaying.List
+	require.Len(t, list, 2)
+
+	// newest first: alice then bob
+	first := list[0]
+	require.Equal(t, 101, first.Id)
+	require.Equal(t, "Track One", first.Title)
+	require.Equal(t, "alice", first.Username)
+	require.Equal(t, 11, first.PlayerId)
+	require.GreaterOrEqual(t, first.MinutesAgo, 0)
+	require.LessOrEqual(t, first.MinutesAgo, 5)
+	second := list[1]
+	require.Equal(t, 202, second.Id)
+	require.Equal(t, "Track Two", second.Title)
+	require.Equal(t, "bob", second.Username)
+	require.Equal(t, 22, second.PlayerId)
+	require.GreaterOrEqual(t, second.MinutesAgo, 29)
+}

--- a/server/ctrlsubsonic/handlers_common_test.go
+++ b/server/ctrlsubsonic/handlers_common_test.go
@@ -46,16 +46,16 @@ func TestServeGetNowPlaying_FromCache(t *testing.T) {
 
 	// newest first: alice then bob
 	first := list[0]
-	require.Equal(t, 101, first.Id)
+	require.Equal(t, 101, first.ID)
 	require.Equal(t, "Track One", first.Title)
 	require.Equal(t, "alice", first.Username)
-	require.Equal(t, 11, first.PlayerId)
+	require.Equal(t, 11, first.PlayerID)
 	require.GreaterOrEqual(t, first.MinutesAgo, 0)
 	require.LessOrEqual(t, first.MinutesAgo, 5)
 	second := list[1]
-	require.Equal(t, 202, second.Id)
+	require.Equal(t, 202, second.ID)
 	require.Equal(t, "Track Two", second.Title)
 	require.Equal(t, "bob", second.Username)
-	require.Equal(t, 22, second.PlayerId)
+	require.Equal(t, 22, second.PlayerID)
 	require.GreaterOrEqual(t, second.MinutesAgo, 29)
 }

--- a/server/ctrlsubsonic/handlers_common_test.go
+++ b/server/ctrlsubsonic/handlers_common_test.go
@@ -1,0 +1,41 @@
+package ctrlsubsonic
+
+import (
+	"fmt"
+	"net/url"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"go.senan.xyz/gonic/db"
+)
+
+func TestGetNowPlaying(t *testing.T) {
+	t.Parallel()
+	f := newFixture(t)
+	f.seq = true
+
+	// fixture plays are from 2020, all outside the one hour window
+	f.run(t, f.contr.ServeGetNowPlaying, f.admin,
+		query{url.Values{}, "empty", false},
+	)
+
+	alt2 := &db.User{Name: "alt2"}
+	require.NoError(t, f.dbc.Where("name=?", "alt2").First(alt2).Error)
+
+	// scrobble tracks admin never played, so the golden file has no admin
+	// "played" timestamps stamped with time.Now()
+	f.query(t, f.contr.ServeScrobble, f.alt, url.Values{
+		"id":   {f.trackVA0.SID().String()},
+		"time": {fmt.Sprint(time.Now().Add(-5 * time.Minute).UnixMilli())},
+	})
+	f.query(t, f.contr.ServeScrobble, alt2, url.Values{
+		"id":   {f.trackAB1.SID().String()},
+		"time": {fmt.Sprint(time.Now().Add(-30 * time.Minute).UnixMilli())},
+	})
+
+	f.run(t, f.contr.ServeGetNowPlaying, f.admin,
+		query{url.Values{}, "recent_plays", false},
+	)
+}

--- a/server/ctrlsubsonic/handlers_raw.go
+++ b/server/ctrlsubsonic/handlers_raw.go
@@ -252,6 +252,32 @@ func (c *Controller) ServeStream(w http.ResponseWriter, r *http.Request) *spec.R
 	format, _ := params.Get("format")
 	timeOffset, _ := params.GetInt("timeOffset")
 
+	// preload Album so we can access album tag/title
+	if id.Type == specid.Track {
+		var tr db.Track
+		if err := c.dbc.Preload("Album").First(&tr, id.Value).Error; err != nil {
+			log.Printf("now_playing: select track %d: %v", id.Value, err)
+		} else {
+			albumTitle := ""
+			if tr.Album != nil {
+				albumTitle = tr.Album.TagTitle
+			}
+			artist := tr.TagTrackArtist
+
+			rec := NowPlayingRecord{
+				TrackID:  tr.ID,
+				Title:    tr.TagTitle,
+				IsDir:    false,
+				Album:    albumTitle,
+				Artist:   artist,
+				Username: user.Name,
+				Time:     time.Now().UTC(),
+				PlayerID: 0,
+			}
+			c.nowPlayingCache.Set(user.ID, rec)
+		}
+	}
+
 	if format == "raw" {
 		http.ServeFile(w, r, file.AbsPath())
 		return nil

--- a/server/ctrlsubsonic/spec/spec.go
+++ b/server/ctrlsubsonic/spec/spec.go
@@ -72,6 +72,8 @@ type Response struct {
 	InternetRadioStations *InternetRadioStations `xml:"internetRadioStations" json:"internetRadioStations,omitempty"`
 	Lyrics                *Lyrics                `xml:"lyrics"                json:"lyrics,omitempty"`
 	LyricsList            *LyricsList            `xml:"lyricsList"            json:"lyricsList,omitempty"`
+	NowPlaying            *NowPlaying            `xml:"nowPlaying"            json:"nowPlaying,omitempty"`
+	NowPlayingEntry       *NowPlayingEntry       `xml:"nowPlayingEntry"       json:"nowPlayingEntry,omitempty"`
 }
 
 func NewResponse() *Response {
@@ -492,6 +494,21 @@ type StructuredLyrics struct {
 	DisplayArtist string  `xml:"displayArtist,attr,omitempty" json:"displayArtist,omitempty"`
 	DisplayTitle  string  `xml:"displayTitle,attr,omitempty" json:"displayTitle,omitempty"`
 	Offset        int     `xml:"offset,attr,omitempty" json:"offset,omitempty"`
+}
+
+type NowPlaying struct {
+	List []*NowPlayingEntry `xml:"entry" json:"entry"`
+}
+
+type NowPlayingEntry struct {
+	Username   string `xml:"username,attr" json:"username"`
+	MinutesAgo int    `xml:"minutesAgo,attr" json:"minutesAgo"`
+	PlayerId   int    `xml:"playerId,attr" json:"playerId"`
+	Id         int    `xml:"id,attr" json:"id"`
+	Title      string `xml:"title,attr" json:"title"`
+	IsDir      bool   `xml:"isDir,attr" json:"isDir"`
+	Album      string `xml:"album,attr" json:"album"`
+	Artist     string `xml:"artist,attr" json:"artist"`
 }
 
 type OpenSubsonicExtension struct {

--- a/server/ctrlsubsonic/spec/spec.go
+++ b/server/ctrlsubsonic/spec/spec.go
@@ -503,8 +503,8 @@ type NowPlaying struct {
 type NowPlayingEntry struct {
 	Username   string `xml:"username,attr" json:"username"`
 	MinutesAgo int    `xml:"minutesAgo,attr" json:"minutesAgo"`
-	PlayerId   int    `xml:"playerId,attr" json:"playerId"`
-	Id         int    `xml:"id,attr" json:"id"`
+	PlayerID   int    `xml:"playerId,attr" json:"playerId"`
+	ID         int    `xml:"id,attr" json:"id"`
 	Title      string `xml:"title,attr" json:"title"`
 	IsDir      bool   `xml:"isDir,attr" json:"isDir"`
 	Album      string `xml:"album,attr" json:"album"`

--- a/server/ctrlsubsonic/spec/spec.go
+++ b/server/ctrlsubsonic/spec/spec.go
@@ -105,7 +105,6 @@ type Response struct {
 	Lyrics                *Lyrics                `xml:"lyrics"                json:"lyrics,omitempty"`
 	LyricsList            *LyricsList            `xml:"lyricsList"            json:"lyricsList,omitempty"`
 	NowPlaying            *NowPlaying            `xml:"nowPlaying"            json:"nowPlaying,omitempty"`
-	NowPlayingEntry       *NowPlayingEntry       `xml:"nowPlayingEntry"       json:"nowPlayingEntry,omitempty"`
 }
 
 func NewResponse() *Response {
@@ -565,14 +564,10 @@ type NowPlaying struct {
 }
 
 type NowPlayingEntry struct {
-	Username   string `xml:"username,attr" json:"username"`
+	TrackChild
+	Username   string `xml:"username,attr"   json:"username"`
 	MinutesAgo int    `xml:"minutesAgo,attr" json:"minutesAgo"`
-	PlayerID   int    `xml:"playerId,attr" json:"playerId"`
-	ID         int    `xml:"id,attr" json:"id"`
-	Title      string `xml:"title,attr" json:"title"`
-	IsDir      bool   `xml:"isDir,attr" json:"isDir"`
-	Album      string `xml:"album,attr" json:"album"`
-	Artist     string `xml:"artist,attr" json:"artist"`
+	PlayerID   int    `xml:"playerId,attr"   json:"playerId"`
 }
 
 type OpenSubsonicExtension struct {

--- a/server/ctrlsubsonic/spec/spec.go
+++ b/server/ctrlsubsonic/spec/spec.go
@@ -104,6 +104,8 @@ type Response struct {
 	InternetRadioStations *InternetRadioStations `xml:"internetRadioStations" json:"internetRadioStations,omitempty"`
 	Lyrics                *Lyrics                `xml:"lyrics"                json:"lyrics,omitempty"`
 	LyricsList            *LyricsList            `xml:"lyricsList"            json:"lyricsList,omitempty"`
+	NowPlaying            *NowPlaying            `xml:"nowPlaying"            json:"nowPlaying,omitempty"`
+	NowPlayingEntry       *NowPlayingEntry       `xml:"nowPlayingEntry"       json:"nowPlayingEntry,omitempty"`
 }
 
 func NewResponse() *Response {
@@ -556,6 +558,21 @@ type StructuredLyrics struct {
 	DisplayArtist string  `xml:"displayArtist,attr,omitempty" json:"displayArtist,omitempty"`
 	DisplayTitle  string  `xml:"displayTitle,attr,omitempty"  json:"displayTitle,omitempty"`
 	Offset        int     `xml:"offset,attr,omitempty"        json:"offset,omitempty"`
+}
+
+type NowPlaying struct {
+	List []*NowPlayingEntry `xml:"entry" json:"entry"`
+}
+
+type NowPlayingEntry struct {
+	Username   string `xml:"username,attr" json:"username"`
+	MinutesAgo int    `xml:"minutesAgo,attr" json:"minutesAgo"`
+	PlayerID   int    `xml:"playerId,attr" json:"playerId"`
+	ID         int    `xml:"id,attr" json:"id"`
+	Title      string `xml:"title,attr" json:"title"`
+	IsDir      bool   `xml:"isDir,attr" json:"isDir"`
+	Album      string `xml:"album,attr" json:"album"`
+	Artist     string `xml:"artist,attr" json:"artist"`
 }
 
 type OpenSubsonicExtension struct {

--- a/server/ctrlsubsonic/testdata/test_get_now_playing_empty
+++ b/server/ctrlsubsonic/testdata/test_get_now_playing_empty
@@ -1,0 +1,12 @@
+{
+  "subsonic-response": {
+    "status": "ok",
+    "version": "1.16.1",
+    "type": "gonic",
+    "serverVersion": "",
+    "openSubsonic": true,
+    "nowPlaying": {
+      "entry": []
+    }
+  }
+}

--- a/server/ctrlsubsonic/testdata/test_get_now_playing_recent_plays
+++ b/server/ctrlsubsonic/testdata/test_get_now_playing_recent_plays
@@ -1,0 +1,188 @@
+{
+  "subsonic-response": {
+    "status": "ok",
+    "version": "1.16.1",
+    "type": "gonic",
+    "serverVersion": "",
+    "openSubsonic": true,
+    "nowPlaying": {
+      "entry": [
+        {
+          "id": "tr-11",
+          "album": "comp",
+          "albumId": "al-17",
+          "artist": "artist-x",
+          "artistId": "ar-20",
+          "artists": [
+            {
+              "id": "ar-20",
+              "name": "artist-x"
+            }
+          ],
+          "displayArtist": "artist-x",
+          "albumArtists": [
+            {
+              "id": "ar-19",
+              "name": "Various Artists"
+            }
+          ],
+          "displayAlbumArtist": "Various Artists",
+          "contributors": [],
+          "displayComposer": "",
+          "bitRate": 100,
+          "contentType": "audio/flac",
+          "coverArt": "tr-11",
+          "created": "2019-11-30T00:00:00Z",
+          "duration": 100,
+          "genre": "Rock",
+          "genres": [
+            {
+              "name": "Rock"
+            }
+          ],
+          "isDir": false,
+          "isVideo": false,
+          "parent": "al-17",
+          "path": "various/comp/track-0.flac",
+          "suffix": "flac",
+          "title": "comp-track-0",
+          "track": 1,
+          "discNumber": 1,
+          "type": "music",
+          "mediaType": "song",
+          "year": 2020,
+          "musicBrainzId": "",
+          "isrc": [],
+          "replayGain": null,
+          "played": "",
+          "username": "alt",
+          "minutesAgo": 5,
+          "playerId": 2
+        },
+        {
+          "id": "tr-4",
+          "album": "album-ab",
+          "albumId": "al-4",
+          "artist": "artist-a",
+          "artistId": "ar-1",
+          "artists": [
+            {
+              "id": "ar-1",
+              "name": "artist-a"
+            }
+          ],
+          "displayArtist": "artist-a",
+          "albumArtists": [
+            {
+              "id": "ar-1",
+              "name": "artist-a"
+            }
+          ],
+          "displayAlbumArtist": "artist-a",
+          "contributors": [
+            {
+              "role": "arranger",
+              "artist": {
+                "id": "ar-10",
+                "name": "arr-a"
+              }
+            },
+            {
+              "role": "composer",
+              "artist": {
+                "id": "ar-4",
+                "name": "Composer A!"
+              }
+            },
+            {
+              "role": "composer",
+              "artist": {
+                "id": "ar-5",
+                "name": "Composer B!"
+              }
+            },
+            {
+              "role": "conductor",
+              "artist": {
+                "id": "ar-8",
+                "name": "cond-a"
+              }
+            },
+            {
+              "role": "lyricist",
+              "artist": {
+                "id": "ar-6",
+                "name": "lyr-a"
+              }
+            },
+            {
+              "role": "lyricist",
+              "artist": {
+                "id": "ar-7",
+                "name": "lyr-b"
+              }
+            },
+            {
+              "role": "producer",
+              "artist": {
+                "id": "ar-9",
+                "name": "prod-a"
+              }
+            },
+            {
+              "role": "remixer",
+              "artist": {
+                "id": "ar-2",
+                "name": "Remixer A!"
+              }
+            },
+            {
+              "role": "remixer",
+              "artist": {
+                "id": "ar-3",
+                "name": "Remixer B!"
+              }
+            }
+          ],
+          "displayComposer": "",
+          "bitRate": 100,
+          "contentType": "audio/flac",
+          "coverArt": "al-4",
+          "created": "2019-11-30T00:00:00Z",
+          "duration": 100,
+          "genre": "Rock",
+          "genres": [
+            {
+              "name": "Rock"
+            },
+            {
+              "name": "Pop"
+            }
+          ],
+          "isDir": false,
+          "isVideo": false,
+          "parent": "al-4",
+          "path": "artist-a/album-ab/d1-track-0.flac",
+          "suffix": "flac",
+          "title": "rich-title-d1",
+          "track": 1,
+          "discNumber": 1,
+          "type": "music",
+          "mediaType": "song",
+          "year": 2019,
+          "musicBrainzId": "00000000-0000-0000-0000-ab00000000d1",
+          "isrc": [],
+          "starred": "2020-05-01T12:00:00Z",
+          "userRating": 3,
+          "averageRating": 4.33,
+          "replayGain": null,
+          "playCount": 1,
+          "played": "2020-08-02T12:00:00Z",
+          "username": "alt2",
+          "minutesAgo": 30,
+          "playerId": 3
+        }
+      ]
+    }
+  }
+}


### PR DESCRIPTION
This is a proof of concept implementation of the getNowPlaying API endpoint (see #510 ). The response NowPlayingEntry only provides the minimal fields required by the OpenSubsonic spec, plus "artist" and "album". The IsDir and and PlayerId fields are hardcoded to false / 0.

I implemented this so I could use [Homepage's Navidrome widget](https://gethomepage.dev/widgets/services/navidrome/) (which is just a generic Subsonic widget that hits the getNowPlaying endpoint and looks for Username, Title, Album, and Artist) as discussed in #533 .

Originally I had created a now_playing table in the database and would insert a row during ServeStream, but that seemed too heavy and invasive, so instead this code relies on an in-memory cache that simply stores the latest track streamed by each user.

Caveats:

- Since the cache is keyed by user, if the same user is streaming to multiple devices, we only see their most recent stream. Lots of ways to change this behavior, but I wanted to get feedback first.
- There's no cache eviction/expiration, but since it is keyed by user it can only grow as large as the number of users.
- Data is not persisted, which seems fine.
- I have not tested this with anything other than regular music tracks (no podcasts, internet radio, etc.)

Questions / Clarifications

- How do we feel about this implementation (cache vs. database table vs. some other method)?
- As far as I could tell, there's no way to get the data needed for getNowPlaying from the database; the plays table only provides album play counts.
- Should we aim to support as many of the optional fields of NowPlayingEntry as possible? Or keep it simple?
- Since getNowPlaying's NowPlayingEntry has a "minutesAgo" field, presumably the endpoint should return entries for recent plays even after the track has ended. Here, I limit returned entries to those within the last 60 minutes.

Full disclosure, I never used Go before this week and this is mostly Copilot code, but I have reviewed it, and I'm running this version of the code on my personal network right now.