### PR TITLE
Treat the `/download` endpoint correctly

### DIFF
--- a/server/ctrlsubsonic/handlers_raw.go
+++ b/server/ctrlsubsonic/handlers_raw.go
@@ -267,6 +267,7 @@ func coverForPlaylist(playlistStore *playlist.Store, id specid.ID) (*os.File, er
 func (c *Controller) ServeStream(w http.ResponseWriter, r *http.Request) *spec.Response {
 	params := r.Context().Value(CtxParams).(params.Params)
 	user := r.Context().Value(CtxUser).(*db.User)
+	urlPath := r.URL.Path
 	id, err := params.GetID("id")
 	if err != nil {
 		return spec.NewError(10, "please provide an `id` parameter")
@@ -286,7 +287,7 @@ func (c *Controller) ServeStream(w http.ResponseWriter, r *http.Request) *spec.R
 	format, _ := params.Get("format")
 	timeOffset, _ := params.GetInt("timeOffset")
 
-	if format == "raw" {
+	if format == "raw" || urlPath == "/download" {
 		http.ServeFile(w, r, file.AbsPath())
 		return nil
 	}


### PR DESCRIPTION
[The Subsonic API has the `/download` endpoint to download raw files](https://subsonic.org/pages/api.jsp#download). This is used by clients to permanently cache or download files for offline use.

In previous versions of Gonic, the `/download` was treated as a `/stream`, with transcoding applied if the server had it configured for the client. In this MR, `/download` is filtered out to serve raw files, regardless of a specified transcoding profile.

I am the sole author of this MR, no generative AI has been used, and I have tested my changes locally against the Supersonic client.