### PR TITLE
feat: add cache size and eject interval for cover art cache

### DIFF
--- a/cmd/gonic/gonic.go
+++ b/cmd/gonic/gonic.go
@@ -98,6 +98,9 @@ func main() {
 	confTranscodeCacheSize := flag.Int("transcode-cache-size", 0, "size of the transcode cache in MB (0 = no limit) (optional)")
 	confTranscodeEjectInterval := flag.Int("transcode-eject-interval", 0, "interval (in minutes) to eject transcode cache (0 = never) (optional)")
 
+	confCoverCacheSize := flag.Int("cover-cache-size", 0, "size of the cover art cache in MB (0 = no limit) (optional)")
+	confCoverEjectInterval := flag.Int("cover-eject-interval", 0, "interval (in minutes) to eject cover art cache (0 = never) (optional)")
+
 	flag.Parse()
 	flagconf.ParseEnv()
 	flagconf.ParseConfig(*confConfigPath)
@@ -259,7 +262,8 @@ func main() {
 	if err != nil {
 		log.Panicf("error creating admin controller: %v\n", err)
 	}
-	ctrlSubsonic, err := ctrlsubsonic.New(dbc, scannr, musicPaths, *confPodcastPath, cacheDirAudio, cacheDirCovers, jukebx, playlistStore, scrobblers, podcast, transcoder, lastfmClient, artistInfoCache, albumInfoCache, tagReader, resolveProxyPath)
+	coverCache := ctrlsubsonic.NewCoverCache(cacheDirCovers, *confCoverCacheSize)
+	ctrlSubsonic, err := ctrlsubsonic.New(dbc, scannr, musicPaths, *confPodcastPath, cacheDirAudio, coverCache, jukebx, playlistStore, scrobblers, podcast, transcoder, lastfmClient, artistInfoCache, albumInfoCache, tagReader, resolveProxyPath)
 	if err != nil {
 		log.Panicf("error creating subsonic controller: %v\n", err)
 	}
@@ -419,6 +423,21 @@ func main() {
 		ctxTick(ctx, time.Duration(*confTranscodeEjectInterval)*time.Minute, func() {
 			if err := transcoder.CacheEject(); err != nil {
 				log.Printf("error ejecting transcode cache: %v", err)
+			}
+		})
+		return nil
+	})
+
+	errgrp.Go(func() error {
+		if *confCoverEjectInterval == 0 || *confCoverCacheSize == 0 {
+			return nil
+		}
+
+		defer logJob("cover cache eject")()
+
+		ctxTick(ctx, time.Duration(*confCoverEjectInterval)*time.Minute, func() {
+			if err := coverCache.CacheEject(); err != nil {
+				log.Printf("error ejecting cover cache: %v", err)
 			}
 		})
 		return nil

--- a/server/ctrlsubsonic/covercache.go
+++ b/server/ctrlsubsonic/covercache.go
@@ -1,0 +1,66 @@
+package ctrlsubsonic
+
+import (
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"sort"
+	"sync"
+)
+
+type CoverCache struct {
+	path      string
+	limitMB   int
+	cleanLock sync.RWMutex
+}
+
+func NewCoverCache(path string, limitMB int) *CoverCache {
+	return &CoverCache{path: path, limitMB: limitMB}
+}
+
+func (c *CoverCache) CacheEject() error {
+	c.cleanLock.Lock()
+	defer c.cleanLock.Unlock()
+
+	type file struct {
+		path string
+		info os.FileInfo
+	}
+
+	var files []file
+	var total int64
+
+	err := filepath.WalkDir(c.path, func(path string, de fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if !de.IsDir() {
+			info, err := de.Info()
+			if err != nil {
+				return fmt.Errorf("stat cover cache file: %w", err)
+			}
+			files = append(files, file{path, info})
+			total += info.Size()
+		}
+		return nil
+	})
+	if err != nil {
+		return fmt.Errorf("walk cover cache path for eject: %w", err)
+	}
+
+	sort.Slice(files, func(i, j int) bool {
+		return files[i].info.ModTime().Before(files[j].info.ModTime())
+	})
+
+	for total > int64(c.limitMB)*1024*1024 {
+		curFile := files[0]
+		files = files[1:]
+		total -= curFile.info.Size()
+		if err := os.Remove(curFile.path); err != nil {
+			return fmt.Errorf("remove cover cache file: %w", err)
+		}
+	}
+
+	return nil
+}

--- a/server/ctrlsubsonic/ctrl.go
+++ b/server/ctrlsubsonic/ctrl.go
@@ -58,7 +58,7 @@ type Controller struct {
 	musicPaths      []MusicPath
 	podcastsPath    string
 	cacheAudioPath  string
-	cacheCoverPath  string
+	coverCache      *CoverCache
 	jukebox         *jukebox.Jukebox
 	playlistStore   *playlist.Store
 	scrobblers      []scrobble.Scrobbler
@@ -72,7 +72,7 @@ type Controller struct {
 	resolveProxyPath ProxyPathResolver
 }
 
-func New(dbc *db.DB, scannr *scanner.Scanner, musicPaths []MusicPath, podcastsPath string, cacheAudioPath string, cacheCoverPath string, jukebox *jukebox.Jukebox, playlistStore *playlist.Store, scrobblers []scrobble.Scrobbler, podcasts *podcast.Podcasts, transcoder transcode.Transcoder, lastFMClient *lastfm.Client, artistInfoCache *artistinfocache.ArtistInfoCache, albumInfoCache *albuminfocache.AlbumInfoCache, tagReader tags.Reader, resolveProxyPath ProxyPathResolver) (*Controller, error) {
+func New(dbc *db.DB, scannr *scanner.Scanner, musicPaths []MusicPath, podcastsPath string, cacheAudioPath string, coverCache *CoverCache, jukebox *jukebox.Jukebox, playlistStore *playlist.Store, scrobblers []scrobble.Scrobbler, podcasts *podcast.Podcasts, transcoder transcode.Transcoder, lastFMClient *lastfm.Client, artistInfoCache *artistinfocache.ArtistInfoCache, albumInfoCache *albuminfocache.AlbumInfoCache, tagReader tags.Reader, resolveProxyPath ProxyPathResolver) (*Controller, error) {
 	c := Controller{
 		ServeMux: http.NewServeMux(),
 
@@ -81,7 +81,7 @@ func New(dbc *db.DB, scannr *scanner.Scanner, musicPaths []MusicPath, podcastsPa
 		musicPaths:      musicPaths,
 		podcastsPath:    podcastsPath,
 		cacheAudioPath:  cacheAudioPath,
-		cacheCoverPath:  cacheCoverPath,
+		coverCache:      coverCache,
 		jukebox:         jukebox,
 		playlistStore:   playlistStore,
 		scrobblers:      scrobblers,

--- a/server/ctrlsubsonic/handlers_raw.go
+++ b/server/ctrlsubsonic/handlers_raw.go
@@ -63,8 +63,11 @@ func (c *Controller) ServeGetCoverArt(w http.ResponseWriter, r *http.Request) *s
 		return spec.NewError(0, "invalid size")
 	}
 
+	c.coverCache.cleanLock.RLock()
+	defer c.coverCache.cleanLock.RUnlock()
+
 	// cached cover could exist for any supported format
-	cachePath, err := findCachedCover(c.cacheCoverPath, id.String(), size)
+	cachePath, err := findCachedCover(c.coverCache.path, id.String(), size)
 	if err != nil && !os.IsNotExist(err) {
 		log.Printf("error checking cache: %v", err)
 		return nil
@@ -76,6 +79,7 @@ func (c *Controller) ServeGetCoverArt(w http.ResponseWriter, r *http.Request) *s
 	}
 
 	if cachePath != "" {
+		_ = os.Chtimes(cachePath, time.Now(), time.Now()) // touch for LRU eviction
 		serve(cachePath)
 		return nil
 	}
@@ -94,11 +98,12 @@ func (c *Controller) ServeGetCoverArt(w http.ResponseWriter, r *http.Request) *s
 	// don't upscale
 	minSize := min(size, max(img.Bounds().Dx(), img.Bounds().Dy()))
 
-	cachePath = filepath.Join(c.cacheCoverPath, coverCacheFilename(id.String(), minSize, format))
+	cachePath = filepath.Join(c.coverCache.path, coverCacheFilename(id.String(), minSize, format))
 
 	if minSize != size {
 		// we down sized, check cache again
 		if _, err := os.Stat(cachePath); err == nil {
+			_ = os.Chtimes(cachePath, time.Now(), time.Now()) // touch for LRU eviction
 			serve(cachePath)
 			return nil
 		}


### PR DESCRIPTION
## Summary

- Adds `-cover-cache-size` (MB) and `-cover-eject-interval` (minutes) flags, mirroring the existing `-transcode-cache-size` / `-transcode-eject-interval` flags
- Introduces `CoverCache` in the `ctrlsubsonic` package, holding the cache path, size limit, and a `sync.RWMutex` to prevent races between cover writes and cache ejection
- `ServeGetCoverArt` holds a read lock for its entire execution; `CacheEject` takes the exclusive write lock before deleting files
- Touches cached cover files on access so LRU ordering is accurate when the eject runs

## Test plan

- [x] Start gonic with `-cover-cache-size 10 -cover-eject-interval 1` and verify covers are served correctly
- [x] Confirm the cache directory is pruned to the size limit after the eject interval elapses
- [x] Verify that omitting either flag (defaulting to 0) disables ejection, matching transcode behaviour
- [x] `go test ./...` passes
- [x] `golangci-lint run` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)