### PR TITLE
feat: track client cover size preference and prefetch on album/song responses

### DIFF
--- a/db/db.go
+++ b/db/db.go
@@ -411,6 +411,12 @@ type TranscodeFormatPreference struct {
 	CreatedAt time.Time
 }
 
+type ClientCoverSizePreference struct {
+	UserID        int    `gorm:"not null; unique_index:idx_client_pref_user_client" sql:"default: null; type:int REFERENCES users(id) ON DELETE CASCADE"`
+	Client        string `gorm:"not null; unique_index:idx_client_pref_user_client" sql:"default: null"`
+	LastCoverSize int    `sql:"default: null"`
+}
+
 type AlbumCredit struct {
 	AlbumID    int    `gorm:"not null; unique_index:idx_album_credit" sql:"default: null; type:int REFERENCES albums(id) ON DELETE CASCADE"`
 	ArtistID   int    `gorm:"not null; unique_index:idx_album_credit; index:idx_album_credits_artist_id" sql:"default: null; type:int REFERENCES artists(id) ON DELETE CASCADE"`

--- a/db/migrations.go
+++ b/db/migrations.go
@@ -88,6 +88,7 @@ func (db *DB) Migrate(ctx MigrationContext) error {
 		construct(ctx, "202604280000", migrateAddCreditedAs),
 		construct(ctx, "202604281200", migrateUnifyCredits),
 		construct(ctx, "202605061812", migrateAddGenreInherited),
+		construct(ctx, "202605061813", migrateAddClientCoverSizePreference),
 		construct(ctx, "202605081200", migrateAddTrackIsrc),
 		construct(ctx, "202605131200", migrateAddArtistCreditDisplay),
 		construct(ctx, "202605221200", migrateAddAlbumLabel),
@@ -943,6 +944,10 @@ func migrateAddTrackYear(tx *gorm.DB, _ MigrationContext) error {
 	}
 
 	return nil
+}
+
+func migrateAddClientCoverSizePreference(tx *gorm.DB, _ MigrationContext) error {
+	return tx.AutoMigrate(ClientCoverSizePreference{}).Error
 }
 
 func migrateAddGenreInherited(tx *gorm.DB, _ MigrationContext) error {

--- a/server/ctrlsubsonic/ctrl.go
+++ b/server/ctrlsubsonic/ctrl.go
@@ -25,6 +25,7 @@ import (
 	"go.senan.xyz/gonic/scrobble"
 	"go.senan.xyz/gonic/server/ctrlsubsonic/params"
 	"go.senan.xyz/gonic/server/ctrlsubsonic/spec"
+	"go.senan.xyz/gonic/server/ctrlsubsonic/specid"
 	"go.senan.xyz/gonic/tags"
 	"go.senan.xyz/gonic/transcode"
 )
@@ -105,6 +106,23 @@ func New(dbc *db.DB, scannr *scanner.Scanner, musicPaths []MusicPath, podcastsPa
 		chain,
 		slow,
 	)
+
+	resp := func(h handlerSubsonic) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			response := h(r)
+			if response != nil && response.Error == nil {
+				if ids := collectCoverIDs(response); len(ids) > 0 {
+					user := r.Context().Value(CtxUser).(*db.User)
+					params := r.Context().Value(CtxParams).(params.Params)
+					client, _ := params.Get("c")
+					go c.prefetchCovers(user.ID, client, ids)
+				}
+			}
+			if err := writeResp(w, r, response); err != nil {
+				log.Printf("error writing subsonic response: %v\n", err)
+			}
+		})
+	}
 
 	c.Handle("/getLicense", chain(resp(c.ServeGetLicence)))
 	c.Handle("/ping", chain(resp(c.ServePing)))
@@ -196,6 +214,119 @@ func resp(h handlerSubsonic) http.Handler {
 			log.Printf("error writing subsonic response: %v\n", err)
 		}
 	})
+}
+
+func (c *Controller) prefetchCovers(userID int, client string, ids []*specid.ID) {
+	var pref db.ClientCoverSizePreference
+	if err := c.dbc.Where("user_id=? AND client=?", userID, client).First(&pref).Error; err != nil {
+		return
+	}
+	if pref.LastCoverSize == 0 {
+		return
+	}
+	seen := make(map[string]bool, len(ids))
+	for _, id := range ids {
+		if id == nil {
+			continue
+		}
+		key := id.String()
+		if seen[key] {
+			continue
+		}
+		seen[key] = true
+		id := id
+		go func() {
+			c.coverCache.RLock()
+			defer c.coverCache.RUnlock()
+			if _, err := findCachedCover(c.coverCache.Path(), id.String(), pref.LastCoverSize); err == nil {
+				return
+			}
+			if _, err := c.ensureCoverCached(*id, pref.LastCoverSize); err != nil {
+				log.Printf("cover prefetch %s: %v", id, err)
+			}
+		}()
+	}
+}
+
+func collectCoverIDs(r *spec.Response) []*specid.ID {
+	var ids []*specid.ID
+	add := func(id *specid.ID) {
+		if id == nil || (id.Type != specid.Album && id.Type != specid.Track) {
+			return
+		}
+		ids = append(ids, id)
+	}
+	addTracks := func(tracks []*spec.TrackChild) {
+		for _, t := range tracks {
+			if t != nil {
+				add(t.CoverID)
+			}
+		}
+	}
+	addAlbums := func(albums []*spec.Album) {
+		for _, a := range albums {
+			if a != nil {
+				add(a.CoverID)
+			}
+		}
+	}
+	if r.Album != nil {
+		add(r.Album.CoverID)
+		addTracks(r.Album.Tracks)
+	}
+	if r.Albums != nil {
+		addAlbums(r.Albums.List)
+	}
+	if r.AlbumsTwo != nil {
+		addAlbums(r.AlbumsTwo.List)
+	}
+	if r.Artist != nil {
+		addAlbums(r.Artist.Albums)
+	}
+	if r.Track != nil {
+		add(r.Track.CoverID)
+	}
+	if r.RandomTracks != nil {
+		addTracks(r.RandomTracks.List)
+	}
+	if r.TracksByGenre != nil {
+		addTracks(r.TracksByGenre.List)
+	}
+	if r.SearchResultTwo != nil {
+		addTracks(r.SearchResultTwo.Albums) // folder-mode albums as TrackChild
+		addTracks(r.SearchResultTwo.Tracks)
+	}
+	if r.SearchResultThree != nil {
+		addAlbums(r.SearchResultThree.Albums)
+		addTracks(r.SearchResultThree.Tracks)
+	}
+	if r.Starred != nil {
+		addTracks(r.Starred.Albums) // folder-mode albums as TrackChild
+		addTracks(r.Starred.Tracks)
+	}
+	if r.StarredTwo != nil {
+		addAlbums(r.StarredTwo.Albums)
+		addTracks(r.StarredTwo.Tracks)
+	}
+	if r.TopSongs != nil {
+		addTracks(r.TopSongs.Tracks)
+	}
+	if r.SimilarSongs != nil {
+		addTracks(r.SimilarSongs.Tracks)
+	}
+	if r.SimilarSongsTwo != nil {
+		addTracks(r.SimilarSongsTwo.Tracks)
+	}
+	if r.PlayQueue != nil {
+		addTracks(r.PlayQueue.List)
+	}
+	if r.Playlist != nil {
+		addTracks(r.Playlist.List)
+	}
+	if r.Directory != nil {
+		addTracks(r.Directory.Children)
+	}
+	return ids
 }
 
 func respRaw(h handlerSubsonicRaw) http.Handler {

--- a/server/ctrlsubsonic/handlers_raw.go
+++ b/server/ctrlsubsonic/handlers_raw.go
@@ -65,6 +65,10 @@ func (c *Controller) ServeGetCoverArt(w http.ResponseWriter, r *http.Request) *s
 		return spec.NewError(0, "invalid size")
 	}
 
+	user := r.Context().Value(CtxUser).(*db.User)
+	client, _ := params.Get("c")
+	go c.recordCoverPreference(user.ID, client, size)
+
 	c.coverCache.RLock()
 	defer c.coverCache.RUnlock()
 
@@ -86,39 +90,57 @@ func (c *Controller) ServeGetCoverArt(w http.ResponseWriter, r *http.Request) *s
 		return nil
 	}
 
-	reader, err := coverFor(c.dbc, c.artistInfoCache, c.playlistStore, c.tagReader, id)
+	cachePath, err = c.ensureCoverCached(id, size)
 	if err != nil {
 		return spec.NewError(70, "couldn't find cover %q: %v", id, err)
+	}
+
+	_ = os.Chtimes(cachePath, time.Now(), time.Now()) // touch for LRU eviction
+	serve(cachePath)
+	return nil
+}
+
+// ensureCoverCached fetches, resizes, and saves the cover for id at up to size pixels.
+// It returns the path of the cached file. Caller must hold c.coverCache.RLock.
+func (c *Controller) ensureCoverCached(id specid.ID, size int) (string, error) {
+	reader, err := coverFor(c.dbc, c.artistInfoCache, c.playlistStore, c.tagReader, id)
+	if err != nil {
+		return "", err
 	}
 	defer reader.Close()
 
 	img, format, err := image.Decode(reader)
 	if err != nil {
-		return spec.NewError(0, "decode for cover %q: %v", id, err)
+		return "", fmt.Errorf("decode cover: %w", err)
 	}
 
 	// don't upscale
 	minSize := min(size, max(img.Bounds().Dx(), img.Bounds().Dy()))
+	cachePath := filepath.Join(c.coverCache.Path(), coverCacheFilename(id.String(), minSize, format))
 
-	cachePath = filepath.Join(c.coverCache.Path(), coverCacheFilename(id.String(), minSize, format))
-
-	if minSize != size {
-		// we down sized, check cache again
-		if _, err := os.Stat(cachePath); err == nil { //nolint:gosec // id.String() constrained, format from image.Decode
-			_ = os.Chtimes(cachePath, time.Now(), time.Now()) // touch for LRU eviction
-			serve(cachePath)
-			return nil
-		}
+	if _, err := os.Stat(cachePath); err == nil { //nolint:gosec // id.String() constrained, format from image.Decode
+		return cachePath, nil // already cached at the effective size
 	}
 
 	resized := imaging.Fit(img, minSize, minSize, imaging.Lanczos)
-
 	if err := imaging.Save(resized, cachePath); err != nil {
-		return spec.NewError(0, "saving cover %q: %v", id, err)
+		return "", fmt.Errorf("save cover: %w", err)
 	}
+	return cachePath, nil
+}
 
-	serve(cachePath)
-	return nil
+func (c *Controller) recordCoverPreference(userID int, client string, size int) {
+	var pref db.ClientCoverSizePreference
+	c.dbc.Where("user_id=? AND client=?", userID, client).First(&pref)
+	if pref.LastCoverSize == size {
+		return
+	}
+	pref.UserID = userID
+	pref.Client = client
+	pref.LastCoverSize = size
+	if err := c.dbc.Save(&pref).Error; err != nil {
+		log.Printf("record cover preference: %v", err)
+	}
 }
 
 func coverCacheFilename(idStr string, size int, format string) string {


### PR DESCRIPTION
## Summary

- Adds a `ClientCoverSizePreference` DB table (with migration) that records the last cover art size requested by each user+client pair, updated on every `getCoverArt` call
- Extracts `ensureCoverCached` from `ServeGetCoverArt` so the resize+save logic is reusable
- Wraps the `resp` handler in `New()` with a local closure that calls `prefetchCovers` after any successful album/song response — no changes to individual handlers required
- `prefetchCovers` looks up the stored size preference for the requesting client and pre-warms the cover cache for all album/track IDs in the response (deduplicated, each in its own goroutine)
- Artist covers are excluded from prefetch since they require external Last.fm HTTP requests

## Test plan

- [ ] First request for `getCoverArt` records size preference in DB
- [ ] Subsequent `getAlbum`/`getAlbumList`/`search3` etc. responses trigger background cache warming at the stored size
- [ ] Cover is served from cache on next `getCoverArt` call without re-encoding
- [ ] No regression on cold-cache cover serving

🤖 Generated with [Claude Code](https://claude.com/claude-code)