### PR TITLE
feat(subsonic): Sorting like file explorers

### DIFF
--- a/db/db.go
+++ b/db/db.go
@@ -170,9 +170,10 @@ func (db *DB) TransactionChunked(data []int64, cb func(*DB, []int64) error) erro
 type SettingKey string
 
 const (
-	LastFMAPIKey SettingKey = "lastfm_api_key" //nolint:gosec
-	LastFMSecret SettingKey = "lastfm_secret"
-	LastScanTime SettingKey = "last_scan_time"
+	LastFMAPIKey     SettingKey = "lastfm_api_key" //nolint:gosec
+	LastFMSecret     SettingKey = "lastfm_secret"
+	LastScanTime     SettingKey = "last_scan_time"
+	LinguisticSorting SettingKey = "linguistic_sorting"
 )
 
 func (db *DB) GetSetting(key SettingKey) (string, error) {
@@ -345,6 +346,7 @@ type Album struct {
 	LeftPath             string `gorm:"unique_index:idx_album_abs_path"`
 	RightPath            string `gorm:"not null; unique_index:idx_album_abs_path" sql:"default: null"`
 	RightPathUDec        string `sql:"default: null"`
+	RightPathSortKey     string `sql:"default: null"`
 	Parent               *Album
 	ParentID             int            `sql:"default: null; type:int REFERENCES albums(id) ON DELETE CASCADE"`
 	RootDir              string         `gorm:"unique_index:idx_album_abs_path" sql:"default: null"`

--- a/db/db.go
+++ b/db/db.go
@@ -170,9 +170,9 @@ func (db *DB) TransactionChunked(data []int64, cb func(*DB, []int64) error) erro
 type SettingKey string
 
 const (
-	LastFMAPIKey     SettingKey = "lastfm_api_key" //nolint:gosec
-	LastFMSecret     SettingKey = "lastfm_secret"
-	LastScanTime     SettingKey = "last_scan_time"
+	LastFMAPIKey      SettingKey = "lastfm_api_key" //nolint:gosec
+	LastFMSecret      SettingKey = "lastfm_secret"
+	LastScanTime      SettingKey = "last_scan_time"
 	LinguisticSorting SettingKey = "linguistic_sorting"
 )
 

--- a/db/migrations.go
+++ b/db/migrations.go
@@ -14,6 +14,8 @@ import (
 	"go.senan.xyz/gonic/fileutil"
 	"go.senan.xyz/gonic/playlist"
 	"go.senan.xyz/gonic/server/ctrlsubsonic/specid"
+	"golang.org/x/text/collate"
+	"golang.org/x/text/language"
 	"gopkg.in/gormigrate.v1"
 )
 
@@ -99,6 +101,7 @@ func (db *DB) Migrate(ctx MigrationContext) error {
 		construct(ctx, "202606051200", migrateDropAverageRating),
 		construct(ctx, "202606091200", migrateArtistInfoFieldsBySource),
 		construct(ctx, "202606091300", migrateAlbumInfoMusicBrainzDisambiguation),
+		construct(ctx, "202607051200", migrateAlbumRightPathSortKey),
 	}
 
 	return gormigrate.
@@ -1060,6 +1063,28 @@ func migrateArtistInfoFieldsBySource(tx *gorm.DB, _ MigrationContext) error {
 		}
 	}
 	return tx.AutoMigrate(ArtistInfo{}).Error
+}
+
+func migrateAlbumRightPathSortKey(tx *gorm.DB, _ MigrationContext) error {
+	if err := tx.AutoMigrate(Album{}).Error; err != nil {
+		return fmt.Errorf("add column: %w", err)
+	}
+	var albums []Album
+	if err := tx.Find(&albums).Error; err != nil {
+		return fmt.Errorf("find albums: %w", err)
+	}
+	cl := collate.New(language.English)
+	buf := &collate.Buffer{}
+	for _, a := range albums {
+		if a.RightPath == "" {
+			continue
+		}
+		sortKey := string(cl.KeyFromString(buf, a.RightPath))
+		if err := tx.Model(&a).Update("right_path_sortkey", sortKey).Error; err != nil {
+			return fmt.Errorf("update album %d sort key: %w", a.ID, err)
+		}
+	}
+	return nil
 }
 
 func migrateAlbumInfoMusicBrainzDisambiguation(tx *gorm.DB, _ MigrationContext) error {

--- a/go.mod
+++ b/go.mod
@@ -35,6 +35,7 @@ require (
 	go.senan.xyz/wrtag v0.32.0
 	golang.org/x/net v0.56.0
 	golang.org/x/sync v0.21.0
+	golang.org/x/text v0.38.0
 	golang.org/x/time v0.15.0
 	gopkg.in/gormigrate.v1 v1.6.0
 )
@@ -68,7 +69,6 @@ require (
 	golang.org/x/crypto v0.53.0 // indirect
 	golang.org/x/image v0.41.0 // indirect
 	golang.org/x/sys v0.46.0 // indirect
-	golang.org/x/text v0.38.0 // indirect
 	gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15 // indirect
 	gopkg.in/natefinch/npipe.v2 v2.0.0-20160621034901-c1b8fa8bdcce // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect

--- a/scanner/scanner.go
+++ b/scanner/scanner.go
@@ -21,6 +21,8 @@ import (
 	"github.com/fsnotify/fsnotify"
 	"github.com/jinzhu/gorm"
 	"github.com/rainycape/unidecode"
+	"golang.org/x/text/collate"
+	"golang.org/x/text/language"
 
 	"go.senan.xyz/gonic/db"
 	"go.senan.xyz/gonic/fileutil"
@@ -32,6 +34,8 @@ import (
 var (
 	ErrAlreadyScanning = errors.New("already scanning")
 	ErrReadingTags     = errors.New("could not read tags")
+	albumSortBuf       = &collate.Buffer{}
+	albumSortCollator  = collate.New(language.English)
 )
 
 type Scanner struct {
@@ -621,6 +625,7 @@ func populateAlbumBasics(tx *db.DB, musicDir string, parent, album *db.Album, di
 	album.RightPath = basename
 	album.Cover = cover
 	album.RightPathUDec = decoded(basename)
+	album.RightPathSortKey = string(albumSortCollator.KeyFromString(albumSortBuf, basename))
 	album.ParentID = parent.ID
 
 	if err := tx.Save(album).Error; err != nil {

--- a/scanner/scanner.go
+++ b/scanner/scanner.go
@@ -34,8 +34,6 @@ import (
 var (
 	ErrAlreadyScanning = errors.New("already scanning")
 	ErrReadingTags     = errors.New("could not read tags")
-	albumSortBuf       = &collate.Buffer{}
-	albumSortCollator  = collate.New(language.English)
 )
 
 type Scanner struct {
@@ -47,6 +45,8 @@ type Scanner struct {
 	scanEmbeddedCover  bool
 	genreTree          map[string][]string
 	scanning           *int32
+	sortBuf            *collate.Buffer
+	sortCollator       *collate.Collator
 }
 
 func New(musicDirs []string, db *db.DB, multiValueSettings map[*tags.Spec]tags.MultiValueSetting, tagReader tags.Reader, excludePattern string, scanEmbeddedCover bool, genreTree map[string][]string) *Scanner {
@@ -64,6 +64,8 @@ func New(musicDirs []string, db *db.DB, multiValueSettings map[*tags.Spec]tags.M
 		scanEmbeddedCover:  scanEmbeddedCover,
 		genreTree:          genreTree,
 		scanning:           new(int32),
+		sortBuf:            &collate.Buffer{},
+		sortCollator:       collate.New(language.English),
 	}
 }
 
@@ -318,7 +320,7 @@ func (s *Scanner) scanDir(st *State, absPath string) error {
 
 	dir, basename := filepath.Split(relPath)
 	var album db.Album
-	if err := populateAlbumBasics(s.db, musicDir, &parent, &album, dir, basename, cover); err != nil {
+	if err := s.populateAlbumBasics(s.db, musicDir, &parent, &album, dir, basename, cover); err != nil {
 		return fmt.Errorf("populate album basics: %w", err)
 	}
 
@@ -610,7 +612,7 @@ func populateAlbum(tx *db.DB, album *db.Album, trags map[string][]string, modTim
 	return nil
 }
 
-func populateAlbumBasics(tx *db.DB, musicDir string, parent, album *db.Album, dir, basename string, cover string) error {
+func (s *Scanner) populateAlbumBasics(tx *db.DB, musicDir string, parent, album *db.Album, dir, basename string, cover string) error {
 	if err := tx.Where("root_dir=? AND left_path=? AND right_path=?", musicDir, dir, basename).First(album).Error; err != nil && !errors.Is(err, gorm.ErrRecordNotFound) {
 		return fmt.Errorf("find album: %w", err)
 	}
@@ -625,7 +627,7 @@ func populateAlbumBasics(tx *db.DB, musicDir string, parent, album *db.Album, di
 	album.RightPath = basename
 	album.Cover = cover
 	album.RightPathUDec = decoded(basename)
-	album.RightPathSortKey = string(albumSortCollator.KeyFromString(albumSortBuf, basename))
+	album.RightPathSortKey = string(s.sortCollator.KeyFromString(s.sortBuf, basename))
 	album.ParentID = parent.ID
 
 	if err := tx.Save(album).Error; err != nil {

--- a/server/ctrladmin/adminui/pages/home.tmpl
+++ b/server/ctrladmin/adminui/pages/home.tmpl
@@ -179,6 +179,20 @@
     </div>
 {{ end }}
 
+{{ component "block" (props .
+    "Icon" "list"
+    "Name" "sorting"
+    "Desc" "folder and album sorting order"
+) }}
+    <form class="contents" action="{{ path "/admin/update_linguistic_sorting_do" }}" method="post">
+        <select class="auto-submit" name="linguistic_sorting">
+            <option value="false" {{ if not .LinguisticSorting }}selected="selected"{{ end }}>bytewise (default)</option>
+            <option value="true" {{ if .LinguisticSorting }}selected="selected"{{ end }}>linguistic (like Finder/Explorer)</option>
+        </select>
+        <p class="text-gray-500 text-left">linguistic sorting uses Unicode Collation, matching how file explorers order files. requires a re-scan to populate sort keys for existing folders.</p>
+    </form>
+{{ end }}
+
 {{ if .User.IsAdmin }}
 {{ component "block" (props .
     "Icon" "rss"

--- a/server/ctrladmin/ctrl.go
+++ b/server/ctrladmin/ctrl.go
@@ -109,6 +109,7 @@ func New(dbc *db.DB, sessDB *gormstore.Store, scanner *scanner.Scanner, podcasts
 	c.Handle("/create_user_do", adminChain(resp(c.ServeCreateUserDo)))
 	c.Handle("/update_lastfm_api_key", adminChain(resp(c.ServeUpdateLastFMAPIKey)))
 	c.Handle("/update_lastfm_api_key_do", adminChain(resp(c.ServeUpdateLastFMAPIKeyDo)))
+	c.Handle("/update_linguistic_sorting_do", adminChain(resp(c.ServeUpdateLinguisticSortingDo)))
 	c.Handle("/start_scan_inc_do", adminChain(resp(c.ServeStartScanIncDo)))
 	c.Handle("/start_scan_full_do", adminChain(resp(c.ServeStartScanFullDo)))
 	c.Handle("/add_podcast_do", adminChain(resp(c.ServePodcastAddDo)))
@@ -298,6 +299,7 @@ type templateData struct {
 	CurrentLastFMAPISecret string
 	DefaultListenBrainzURL string
 	SelectedUser           *db.User
+	LinguisticSorting      bool
 
 	Podcasts              []*db.Podcast
 	InternetRadioStations []*db.InternetRadioStation

--- a/server/ctrladmin/handlers.go
+++ b/server/ctrladmin/handlers.go
@@ -110,6 +110,13 @@ func (c *Controller) ServeHome(r *http.Request) *Response {
 		return &Response{code: 500, err: fmt.Sprintf("error finding internet radio stations: %v", err)}
 	}
 
+	// sorting box
+	sortVal, err := c.dbc.GetSetting(db.LinguisticSorting)
+	if err != nil {
+		return &Response{code: 500, err: fmt.Sprintf("error getting sorting setting: %v", err)}
+	}
+	data.LinguisticSorting = sortVal == "true"
+
 	return &Response{
 		template: "home.tmpl",
 		data:     data,
@@ -380,6 +387,14 @@ func (c *Controller) ServeUpdateLastFMAPIKeyDo(r *http.Request) *Response {
 	}
 	if err := c.dbc.SetSetting(db.LastFMSecret, secret); err != nil {
 		return &Response{redirect: r.Referer(), flashW: []string{fmt.Sprintf("couldn't set secret: %v", err)}}
+	}
+	return &Response{redirect: "/admin/home"}
+}
+
+func (c *Controller) ServeUpdateLinguisticSortingDo(r *http.Request) *Response {
+	val := r.FormValue("linguistic_sorting")
+	if err := c.dbc.SetSetting(db.LinguisticSorting, val); err != nil {
+		return &Response{redirect: r.Referer(), flashW: []string{fmt.Sprintf("couldn't set sorting: %v", err)}}
 	}
 	return &Response{redirect: "/admin/home"}
 }

--- a/server/ctrlsubsonic/ctrl.go
+++ b/server/ctrlsubsonic/ctrl.go
@@ -35,6 +35,7 @@ const (
 	CtxUser CtxKey = iota
 	CtxSession
 	CtxParams
+	linguisticSortingEnabled = "true"
 )
 
 type MusicPath struct {
@@ -75,7 +76,7 @@ type Controller struct {
 
 func (c *Controller) sortRightPath() string {
 	v, err := c.dbc.GetSetting(db.LinguisticSorting)
-	if err != nil || v != "true" {
+	if err != nil || v != linguisticSortingEnabled {
 		return "right_path COLLATE NOCASE"
 	}
 	return "right_path_sort_key"
@@ -83,7 +84,7 @@ func (c *Controller) sortRightPath() string {
 
 func (c *Controller) sortRightPathPrefixed() string {
 	v, err := c.dbc.GetSetting(db.LinguisticSorting)
-	if err != nil || v != "true" {
+	if err != nil || v != linguisticSortingEnabled {
 		return "albums.right_path COLLATE NOCASE"
 	}
 	return "albums.right_path_sort_key"
@@ -91,7 +92,7 @@ func (c *Controller) sortRightPathPrefixed() string {
 
 func (c *Controller) sortRightPathParentPrefixed() string {
 	v, err := c.dbc.GetSetting(db.LinguisticSorting)
-	if err != nil || v != "true" {
+	if err != nil || v != linguisticSortingEnabled {
 		return "parent_albums.right_path"
 	}
 	return "parent_albums.right_path_sort_key"

--- a/server/ctrlsubsonic/ctrl.go
+++ b/server/ctrlsubsonic/ctrl.go
@@ -73,6 +73,30 @@ type Controller struct {
 	resolveProxyPath ProxyPathResolver
 }
 
+func (c *Controller) sortRightPath() string {
+	v, err := c.dbc.GetSetting(db.LinguisticSorting)
+	if err != nil || v != "true" {
+		return "right_path COLLATE NOCASE"
+	}
+	return "right_path_sort_key"
+}
+
+func (c *Controller) sortRightPathPrefixed() string {
+	v, err := c.dbc.GetSetting(db.LinguisticSorting)
+	if err != nil || v != "true" {
+		return "albums.right_path COLLATE NOCASE"
+	}
+	return "albums.right_path_sort_key"
+}
+
+func (c *Controller) sortRightPathParentPrefixed() string {
+	v, err := c.dbc.GetSetting(db.LinguisticSorting)
+	if err != nil || v != "true" {
+		return "parent_albums.right_path"
+	}
+	return "parent_albums.right_path_sort_key"
+}
+
 func New(dbc *db.DB, scannr *scanner.Scanner, musicPaths []MusicPath, podcastsPath string, cacheAudioPath string, coverCache *cache.DirCache, jukebox *jukebox.Jukebox, playlistStore *playlist.Store, scrobblers []scrobble.Scrobbler, podcasts *podcast.Podcasts, transcoder transcode.Transcoder, lastFMClient *lastfm.Client, artistInfoCache *artistinfocache.ArtistInfoCache, albumInfoCache *albuminfocache.AlbumInfoCache, tagReader tags.Reader, resolveProxyPath ProxyPathResolver) (*Controller, error) {
 	c := Controller{
 		ServeMux: http.NewServeMux(),

--- a/server/ctrlsubsonic/handlers_by_folder.go
+++ b/server/ctrlsubsonic/handlers_by_folder.go
@@ -32,7 +32,7 @@ func (c *Controller) ServeGetIndexes(r *http.Request) *spec.Response {
 	err := c.dbc.
 		Scopes(spec.AlbumWithChildAlbumCounts, spec.AlbumWithUserData(user.ID)).
 		Where("albums.parent_id IN ?", rootQ.SubQuery()).
-		Order("albums.right_path COLLATE NOCASE").
+		Order(c.sortRightPathPrefixed()).
 		Find(&folders).
 		Error
 	if err != nil {
@@ -85,7 +85,7 @@ func (c *Controller) ServeGetMusicDirectory(r *http.Request) *spec.Response {
 		Scopes(spec.LoadAlbumByFolder(user.ID)).
 		Where("parent_id=?", id.Value).
 		Order("tag_year").
-		Order("albums.right_path COLLATE NOCASE").
+		Order(c.sortRightPathPrefixed()).
 		Find(&childFolders).
 		Error
 	if err != nil {
@@ -138,9 +138,9 @@ func (c *Controller) ServeGetAlbumList(r *http.Request) *spec.Response {
 		q = q.Joins(`
 			JOIN albums parent_albums
 			ON albums.parent_id=parent_albums.id`)
-		q = q.Order("parent_albums.right_path")
+		q = q.Order(c.sortRightPathParentPrefixed())
 	case "alphabeticalByName":
-		q = q.Order("right_path")
+		q = q.Order(c.sortRightPath())
 	case "byYear":
 		y1, y2 := params.GetOrInt("fromYear", 1800),
 			params.GetOrInt("toYear", 2200)
@@ -151,7 +151,7 @@ func (c *Controller) ServeGetAlbumList(r *http.Request) *spec.Response {
 		genre, _ := params.Get("genre")
 		q = q.Joins("JOIN album_genres ON album_genres.album_id=albums.id")
 		q = q.Joins("JOIN genres ON genres.id=album_genres.genre_id AND genres.name=?", genre)
-		q = q.Order("right_path")
+		q = q.Order(c.sortRightPath())
 	case "frequent":
 		q = q.Having("play_length > 0").Order("play_length DESC")
 	case "newest":
@@ -162,7 +162,7 @@ func (c *Controller) ServeGetAlbumList(r *http.Request) *spec.Response {
 		q = q.Having("play_time IS NOT NULL").Order("play_time DESC")
 	case "starred":
 		q = q.Joins("JOIN album_stars ON albums.id=album_stars.album_id AND album_stars.user_id=?", user.ID)
-		q = q.Order("right_path")
+		q = q.Order(c.sortRightPath())
 	case "highest":
 		q = q.Joins("JOIN album_ratings ON album_ratings.album_id=albums.id AND album_ratings.user_id=?", user.ID)
 		q = q.Order("album_ratings.rating DESC")

--- a/server/ctrlsubsonic/handlers_by_tags.go
+++ b/server/ctrlsubsonic/handlers_by_tags.go
@@ -90,7 +90,7 @@ func (c *Controller) ServeGetArtist(r *http.Request) *spec.Response {
 				JOIN tracks ON tracks.id=track_credits.track_id
 				WHERE track_credits.artist_id=?
 		)`, artist.ID, artist.ID).
-		Order("albums.right_path").
+		Order(c.sortRightPathPrefixed()).
 		Find(&appearances).Error; err != nil {
 		return spec.NewError(0, "find artist appearances: %v", err)
 	}


### PR DESCRIPTION
Good day!

I thought it makes sense to have option to see folders sorted just like you see them in file explorers. Certainly makes my live easier =) 

### Problem

Gonic sorts folder listings by `right_path COLLATE NOCASE` — raw bytewise comparison. This means `(` sorts before `_` (ASCII 40 vs 95).  
File explorers (Finder, Explorer, Nautilus) use the Unicode Collation Algorithm, which gives `_` a lower weight than `(` — so `_1` comes before `(1992) One`.

### Solution

**Pre-computed sort key column** — same approach file explorers use under the hood.
linguistic (UCA-based) folder sorting with admin toggle

<img width="844" height="154" alt="Screenshot 2026-07-05 at 18 17 56" src="https://github.com/user-attachments/assets/012cfe7d-f7c4-4f1e-8637-a72c3023a94a" />


#### What changed (10 files)

- **`db/db.go`** — Added `RightPathSortKey` field to `Album` model + new `LinguisticSorting` setting key
- **`db/migrations.go`** — Migration `202607051200` adds the column via `AutoMigrate` and backfills sort keys for all existing albums using `golang.org/x/text/collate`
- **`scanner/scanner.go`** — `populateAlbumBasics` always writes a UCA sort key from the directory basename during scan
- **`server/ctrlsubsonic/ctrl.go`** — Three helper methods (`sortRightPath`, `sortRightPathPrefixed`, `sortRightPathParentPrefixed`) that check the `linguistic_sorting` setting and return either `right_path_sort_key` or `right_path COLLATE NOCASE`
- **`server/ctrlsubsonic/handlers_by_folder.go`** — All 6 `ORDER BY` clauses switched to use helpers
- **`server/ctrlsubsonic/handlers_by_tags.go`** — Tag-mode artist album listing switched to use helper
- **`server/ctrladmin/handlers.go`** — Loads setting in `ServeHome`, added POST handler to save toggle
- **`server/ctrladmin/ctrl.go`** — Registered route, added `LinguisticSorting` to template data
- **`server/ctrladmin/adminui/pages/home.tmpl`** — New "sorting" block with dropdown (bytewise / linguistic)
- **`go.mod`** — Promoted `golang.org/x/text` to direct dependency

#### How it works

The sort key is always written during scanning regardless of the toggle. The toggle (`/admin/home` → **sorting** dropdown) only changes which column the `ORDER BY` uses at query time — zero-rebuild, instant switch. Migration backfills existing albums so there's no gap.

#### Migration behavior

On upgrade, `migrateAlbumRightPathSortKey`:
1. Adds `right_path_sort_key TEXT` column via `AutoMigrate`
2. Iterates all albums and sets the sort key from `right_path` using UCA
3. No downtime — column is nullable, next scan fills any newly added albums