### PR TITLE
feat(ffprobe): Consider stream tags

### DIFF
--- a/tags/ffprobe/ffprobe.go
+++ b/tags/ffprobe/ffprobe.go
@@ -49,21 +49,18 @@ func (Reader) Read(absPath string) (tags.Properties, tags.Tags, error) {
 	bitRateBitsPerSec, _ := strconv.Atoi(d.Format.BitRate)
 
 	var tgs = map[string][]string{}
-	var hasCover, tgsFound bool
+	var hasCover bool
 	for _, s := range d.Streams {
 		switch s.CodecType {
 		case "video":
 			hasCover = true
 		case "audio":
-			if !tgsFound {
-				tgsFound = true
-				for k, vs := range s.Tags {
-					tgs[k] = strings.Split(vs, ";")
-				}
+			if len(tgs) > 0 {
+				continue // first audio stream wins
 			}
-		}
-		if hasCover && tgsFound {
-			break
+			for k, vs := range s.Tags {
+				tgs[k] = strings.Split(vs, ";")
+			}
 		}
 	}
 	for k, vs := range d.Format.Tags {

--- a/tags/ffprobe/ffprobe.go
+++ b/tags/ffprobe/ffprobe.go
@@ -25,14 +25,15 @@ func (Reader) CanRead(absPath string) bool {
 }
 
 func (Reader) Read(absPath string) (tags.Properties, tags.Tags, error) {
-	out, err := exec.Command("ffprobe", "-hide_banner", "-v", "0", "-i", absPath, "-show_entries", "format:stream=codec_type", "-of", "json").Output()
+	out, err := exec.Command("ffprobe", "-hide_banner", "-v", "0", "-i", absPath, "-show_entries", "format:stream=codec_type:stream_tags", "-of", "json").Output()
 	if err != nil {
 		return tags.Properties{}, nil, fmt.Errorf("output: %w", err)
 	}
 
 	var d struct {
 		Streams []struct {
-			CodecType string `json:"codec_type"`
+			CodecType string            `json:"codec_type"`
+			Tags      map[string]string `json:"tags"`
 		} `json:"streams"`
 		Format struct {
 			Duration string            `json:"duration"`
@@ -48,20 +49,29 @@ func (Reader) Read(absPath string) (tags.Properties, tags.Tags, error) {
 	bitRateBitsPerSec, _ := strconv.Atoi(d.Format.BitRate)
 
 	var tgs = map[string][]string{}
+	var hasCover, tgsFound bool
+	for _, s := range d.Streams {
+		switch s.CodecType {
+		case "video":
+			hasCover = true
+		case "audio":
+			if !tgsFound {
+				tgsFound = true
+				for k, vs := range s.Tags {
+					tgs[k] = strings.Split(vs, ";")
+				}
+			}
+		}
+		if hasCover && tgsFound {
+			break
+		}
+	}
 	for k, vs := range d.Format.Tags {
 		switch k {
 		case "OK":
 			continue
 		}
 		tgs[k] = strings.Split(vs, ";")
-	}
-
-	var hasCover bool
-	for _, s := range d.Streams {
-		if s.CodecType == "video" {
-			hasCover = true
-			break
-		}
 	}
 
 	props := tags.Properties{


### PR DESCRIPTION
In my library, some songs show their artist, album, title and track number only in the stream tags, not in the `format` section of `ffprobe`. With this fix, the stream tags are considered, but the `format` tags would still overwrite the stream tags, if they are available additionally.

If there are multiple streams with stream tags, things will probably get ugly, but at least in my library, this doesn't seem to occur.

Fixes #716 (even the ignored album; I don't quite understand how - was it because problematic and unproblematic songs were mixed in one directory?!)